### PR TITLE
UseCorrade checks existing -std= flags before adding.

### DIFF
--- a/modules/UseCorrade.cmake
+++ b/modules/UseCorrade.cmake
@@ -75,9 +75,11 @@ endif()
 # GCC/Clang-specific compiler flags
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR CORRADE_TARGET_EMSCRIPTEN)
     # Mandatory C++ flags
-    # TODO: use -std=c++11 when we don't have to maintain compatibility with
-    # anything older than GCC 4.7
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-std=c[+][+](0x|11|1y)")
+        # TODO: use -std=c++11 when we don't have to maintain compatibility with
+        # anything older than GCC 4.7
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    endif()
 
     # Optional C++ flags
     set(CORRADE_CXX_FLAGS "-Wall -Wextra -Wold-style-cast -Winit-self -Werror=return-type -Wmissing-declarations -pedantic -fvisibility=hidden")


### PR DESCRIPTION
This way if CMAKE_CXX_FLAGS already contains c++0x, c++11 or c++1y, Corrade does not accidentally override.
