### PR TITLE
Adds std::ostream fallback to Utility::Debug.

### DIFF
--- a/src/Corrade/Utility/Debug.cpp
+++ b/src/Corrade/Utility/Debug.cpp
@@ -31,6 +31,20 @@
 
 namespace Corrade { namespace Utility {
 
+namespace {
+
+template <typename T>
+inline void toStream(std::ostream& s, const T& value) {
+    s << value;
+}
+
+template <>
+inline void toStream<Debug::Fallback>(std::ostream& s, const Debug::Fallback& value) {
+    value.apply(s);
+}
+
+}
+
 std::ostream* Debug::globalOutput = &std::cout;
 std::ostream* Warning::globalWarningOutput = &std::cerr;
 std::ostream* Error::globalErrorOutput = &std::cerr;
@@ -82,7 +96,7 @@ template<class T> Debug Debug::print(const T& value) {
     if(flags & 0x01) flags &= ~0x01;
     else if(flags & Debug::SpaceAfterEachValue) *output << " ";
 
-    *output << value;
+    toStream(*output, value);
     return *this;
 }
 
@@ -111,5 +125,7 @@ Debug Debug::operator<<(char32_t value) {
 Debug Debug::operator<<(const char32_t* value) {
     return *this << std::u32string(value);
 }
+
+Debug Debug::operator<<(Fallback value) { return print(value); }
 
 }}

--- a/src/Corrade/Utility/Debug.h
+++ b/src/Corrade/Utility/Debug.h
@@ -29,6 +29,7 @@
  * @brief Class @ref Corrade::Utility::Debug, @ref Corrade::Utility::Warning, @ref Corrade::Utility::Error
  */
 
+#include <functional>
 #include <iosfwd>
 #include <utility>
 #include <type_traits>
@@ -201,6 +202,18 @@ class CORRADE_UTILITY_EXPORT Debug {
          * `[U+0061, U+0062, U+0063}`.
          */
         Debug operator<<(const char32_t* value);        /**< @overload */
+
+        struct Fallback {
+            // Implicit construction is desired.
+            template <class T>
+            Fallback(const T& t)
+                : apply([&] (std::ostream& s) { s << t; })
+            { }
+
+            std::function<void(std::ostream&)> apply;
+        };
+
+        Debug operator<<(Fallback value);
 
         /**
          * @brief Globally set output for newly created instances


### PR DESCRIPTION
Debug's operator<< now uses the new Debug::Fallback type to provide a worst-match overloaded operator<< that only applies when a type has no operator<< for Debug but does have operator<< for std::ostream&.
