### PR TITLE
Debug: Fixes ambiguous overload issues in ostream fallback.

### DIFF
--- a/src/Corrade/Utility/Debug.cpp
+++ b/src/Corrade/Utility/Debug.cpp
@@ -31,18 +31,6 @@
 
 namespace Corrade { namespace Utility {
 
-namespace {
-
-template<class T> inline void toStream(std::ostream& s, const T& value) {
-    s << value;
-}
-
-template<> inline void toStream<Implementation::DebugOstreamFallback>(std::ostream& s, const Implementation::DebugOstreamFallback& value) {
-    value.apply(s);
-}
-
-}
-
 std::ostream* Debug::globalOutput = &std::cout;
 std::ostream* Warning::globalWarningOutput = &std::cerr;
 std::ostream* Error::globalErrorOutput = &std::cerr;
@@ -94,7 +82,7 @@ template<class T> Debug Debug::print(const T& value) {
     if(flags & 0x01) flags &= ~0x01;
     else if(flags & Debug::SpaceAfterEachValue) *output << " ";
 
-    toStream(*output, value);
+    *output << value;
     return *this;
 }
 
@@ -125,9 +113,17 @@ Debug Debug::operator<<(const char32_t* value) {
 }
 
 #ifndef DOXYGEN_GENERATING_OUTPUT
-Debug Debug::operator<<(Implementation::DebugOstreamFallback&& value) {
-    return print(value);
+Debug operator<<(Implementation::DebugOstreamFallback fallback, Implementation::DebugOstreamFallbackValue&& value) {
+    return fallback.debug.print(value);
 }
 #endif
+
+namespace Implementation {
+
+std::ostream& operator<<(std::ostream& o, const Implementation::DebugOstreamFallbackValue& value) {
+    return (value.*value.applier)(o);
+}
+
+}
 
 }}


### PR DESCRIPTION
Debug fallback printing is now accomplished through an `operator<<` that requires an implicit conversion for both the left and right hand sides. This ensures that the fallback `operator<<` is only selected when all else fails.

In particular, any rhs value that is implicitly convertible to a type that has `operator<<(Debug)` will match that operator, rather than the fallback.
