### PR TITLE
Fixes compilation on MSVC2015. interface is a reserved keyword 

### DIFF
--- a/src/Corrade/PluginManager/AbstractManager.cpp
+++ b/src/Corrade/PluginManager/AbstractManager.cpp
@@ -113,7 +113,7 @@ AbstractManager::AbstractManager(std::string pluginInterface, std::string plugin
     /* Find static plugins which have the same interface and have not
         assigned manager to them */
     for(auto p: _plugins.plugins) {
-        if(p.second->loadState != LoadState::Static || p.second->manager != nullptr || p.second->staticPlugin->interface != _pluginInterface)
+        if(p.second->loadState != LoadState::Static || p.second->manager != nullptr || p.second->staticPlugin->interfaceName != _pluginInterface)
             continue;
 
         /* Assign the plugin to this manager and initialize it */

--- a/src/Corrade/PluginManager/AbstractManager.h
+++ b/src/Corrade/PluginManager/AbstractManager.h
@@ -217,7 +217,7 @@ class CORRADE_PLUGINMANAGER_EXPORT AbstractManager {
 
         #ifndef DOXYGEN_GENERATING_OUTPUT
         typedef void* (*Instancer)(AbstractManager&, std::string);
-        static void importStaticPlugin(std::string plugin, int _version, std::string interface, Instancer instancer, void(*initializer)(), void(*finalizer)());
+        static void importStaticPlugin(std::string plugin, int _version, std::string interfaceName, Instancer instancer, void(*initializer)(), void(*finalizer)());
         #endif
 
         /** @brief Copying is not allowed */
@@ -354,7 +354,7 @@ class CORRADE_PLUGINMANAGER_EXPORT AbstractManager {
     #endif
         struct StaticPlugin {
             std::string plugin;
-            std::string interface;
+            std::string interfaceName;
             Instancer instancer;
             void(*initializer)();
             void(*finalizer)();


### PR DESCRIPTION
In MSVC2015, 'interface' is a reserved keyword and causes compilation errors when referenced via the Corrade templates; the error is only present once the tempalte is actually instantiated. I've simply renamed its two instances to interfaceName for compilation to work.