### PR TITLE
Interconnect: Use () instead of {} in constructor because of MSVC.

### DIFF
--- a/src/Corrade/Interconnect/Emitter.h
+++ b/src/Corrade/Interconnect/Emitter.h
@@ -416,7 +416,7 @@ template<class Receiver, class ...Args> class MemberConnectionData: public BaseM
     public:
         typedef void(Receiver::*Slot)(Args...);
 
-        template<class Emitter> explicit MemberConnectionData(Emitter* emitter, Receiver* receiver, void(Receiver::*slot)(Args...)): BaseMemberConnectionData<Args...>{emitter, receiver}, _receiver{receiver}, _slot{slot} {}
+        template<class Emitter> explicit MemberConnectionData(Emitter* emitter, Receiver* receiver, void(Receiver::*slot)(Args...)): BaseMemberConnectionData<Args...>(emitter, receiver), _receiver{receiver}, _slot{slot} {}
 
     private:
         void handle(Args... args) override final {


### PR DESCRIPTION
Hi @mosra !

**It's one of these again!**

This just popped up today. On MSVC I got a syntax error trying to compile `Corrade::Interconnect`.
A collegue reported ee4bbeb2e4c1003d7bbed4821ea074e8857f7b34 to compile fine (a few later may also work).

I found out that this is one of the cases where MSVC did not like the `{}` while calling a superconstructor.
Since the CI compiled without complaints, I am guessing this may be fine with ["Visual Studio Update 3"](https://www.visualstudio.com/en-us/news/releasenotes/vs2015-update3-vs)?
I will install that and report back whether that compiles without this change.

Greetings, Squareys.
