### PR TITLE
Fix compilation issue related to CORRADE_NORETURN being undefined

### DIFF
--- a/src/Corrade/Utility/Debug.h
+++ b/src/Corrade/Utility/Debug.h
@@ -34,6 +34,7 @@
 #include <tuple>
 #include <type_traits>
 
+#include "Corrade/Utility/Macros.h"
 #include "Corrade/Containers/EnumSet.h"
 #include "Corrade/Utility/TypeTraits.h"
 #include "Corrade/Utility/Utility.h"


### PR DESCRIPTION
CORRADE_NORETURN is defined in the Macros.h file, which is not included by Debug.h.
Adding it back restores compilability on modern versions of GCC/Clang