### PR TITLE
Modernize Corrade

### DIFF
--- a/src/Corrade/Interconnect/Connection.cpp
+++ b/src/Corrade/Interconnect/Connection.cpp
@@ -32,7 +32,7 @@
 
 namespace Corrade { namespace Interconnect {
 
-Connection::Connection(Connection&& other) noexcept: _signal{std::move(other._signal)}, _data{std::move(other._data)}, _connected{std::move(other._connected)} {
+Connection::Connection(Connection&& other) noexcept: _signal{other._signal}, _data{other._data}, _connected{other._connected} {
     if(_data) _data->_connection = this;
     other._data = nullptr;
     other._connected = false;

--- a/src/Corrade/Interconnect/Emitter.cpp
+++ b/src/Corrade/Interconnect/Emitter.cpp
@@ -32,7 +32,7 @@ namespace Corrade { namespace Interconnect {
 
 namespace Implementation {
 
-AbstractConnectionData::~AbstractConnectionData() {}
+AbstractConnectionData::~AbstractConnectionData() = default;
 
 }
 

--- a/src/Corrade/Interconnect/Receiver.cpp
+++ b/src/Corrade/Interconnect/Receiver.cpp
@@ -60,22 +60,22 @@ Receiver::~Receiver() {
 }
 
 void Receiver::disconnectAllSlots() {
-    for(auto it = _connections.begin(); it != _connections.end(); ++it) {
+    for(auto & _connection : _connections) {
         /* Remove connection from emitter */
-        for(auto end = (*it)->_emitter->_connections.end(), eit = (*it)->_emitter->_connections.begin(); eit != end; ++eit) {
-            if(eit->second != *it) continue;
+        for(auto end = _connection->_emitter->_connections.end(), eit = _connection->_emitter->_connections.begin(); eit != end; ++eit) {
+            if(eit->second != _connection) continue;
 
-            (*it)->_emitter->_connections.erase(eit);
-            (*it)->_emitter->_connectionsChanged = true;
+            _connection->_emitter->_connections.erase(eit);
+            _connection->_emitter->_connectionsChanged = true;
             break;
         }
 
         /* If there is no connection object, destroy also connection data (as we
            are the last remaining owner) */
-        if(!(*it)->_connection) delete *it;
+        if(!_connection->_connection) delete _connection;
 
         /* Else mark the connection as disconnected */
-        else (*it)->_connection->_connected = false;
+        else _connection->_connection->_connected = false;
     }
 
     _connections.clear();

--- a/src/Corrade/PluginManager/AbstractManager.cpp
+++ b/src/Corrade/PluginManager/AbstractManager.cpp
@@ -360,7 +360,7 @@ LoadState AbstractManager::loadInternal(Plugin& plugin) {
             return LoadState::UnresolvedDependency;
         }
 
-        dependencies.push_back(*foundDependency->second);
+        dependencies.emplace_back(*foundDependency->second);
     }
 
     const std::string filename = Directory::join(_pluginDirectory, plugin.metadata._name + PLUGIN_FILENAME_SUFFIX);

--- a/src/Corrade/PluginManager/AbstractManager.cpp
+++ b/src/Corrade/PluginManager/AbstractManager.cpp
@@ -171,9 +171,9 @@ AbstractManager::~AbstractManager() {
 
     #if !defined(CORRADE_TARGET_NACL_NEWLIB) && !defined(CORRADE_TARGET_EMSCRIPTEN) && !defined(CORRADE_TARGET_WINDOWS_RT) && !defined(CORRADE_TARGET_IOS) && !defined(CORRADE_TARGET_ANDROID)
     /* Remove the plugins from global container */
-    for(auto it = removed.cbegin(); it != removed.cend(); ++it) {
-        delete (*it)->second;
-        _plugins.plugins.erase(*it);
+    for(auto it : removed) {
+        delete it->second;
+        _plugins.plugins.erase(it);
     }
     #endif
 }
@@ -272,12 +272,12 @@ void AbstractManager::reloadPluginDirectory() {
 
 std::vector<std::string> AbstractManager::pluginList() const {
     std::vector<std::string> names;
-    for(auto i = _plugins.plugins.cbegin(); i != _plugins.plugins.cend(); ++i) {
+    for(const auto & plugin : _plugins.plugins) {
 
         /* Plugin doesn't belong to this manager */
-        if(i->second->manager != this) continue;
+        if(plugin.second->manager != this) continue;
 
-        names.push_back(i->first);
+        names.push_back(plugin.first);
     }
     return names;
 }
@@ -381,7 +381,7 @@ LoadState AbstractManager::loadInternal(Plugin& plugin) {
     #ifdef __GNUC__ /* http://www.mr-edd.co.uk/blog/supressing_gcc_warnings */
     __extension__
     #endif
-    int (*_version)(void) = reinterpret_cast<int(*)()>(dlsym(module, "pluginVersion"));
+    int (*_version)() = reinterpret_cast<int(*)()>(dlsym(module, "pluginVersion"));
     if(_version == nullptr) {
         Error() << "PluginManager::Manager::load(): cannot get version of plugin" << plugin.metadata._name + ":" << dlerror();
         dlclose(module);
@@ -476,8 +476,8 @@ LoadState AbstractManager::unloadInternal(Plugin& plugin) {
     auto foundInstance = _instances.find(plugin.metadata._name);
     if(foundInstance != _instances.end()) {
         /* Check if all instances can be safely deleted */
-        for(auto it = foundInstance->second.cbegin(); it != foundInstance->second.cend(); ++it)
-            if(!(*it)->canBeDeleted()) {
+        for(auto it : foundInstance->second)
+            if(!it->canBeDeleted()) {
                 Error() << "PluginManager::Manager::unload(): plugin" << plugin.metadata._name << "is currently used and cannot be deleted";
                 return LoadState::Used;
             }

--- a/src/Corrade/TestSuite/Compare/File.cpp
+++ b/src/Corrade/TestSuite/Compare/File.cpp
@@ -26,6 +26,7 @@
 #include "File.h"
 
 #include <cstddef>
+#include <utility>
 #ifdef _MSC_VER
 #include <algorithm> /* std::max() */
 #endif
@@ -35,7 +36,7 @@
 
 namespace Corrade { namespace TestSuite {
 
-Comparator<Compare::File>::Comparator(const std::string& pathPrefix): _actualState{State::ReadError}, _expectedState{State::ReadError}, _pathPrefix{pathPrefix} {}
+Comparator<Compare::File>::Comparator(std::string  pathPrefix): _actualState{State::ReadError}, _expectedState{State::ReadError}, _pathPrefix{std::move(pathPrefix)} {}
 
 bool Comparator<Compare::File>::operator()(const std::string& actualFilename, const std::string& expectedFilename) {
     _actualFilename = Utility::Directory::join(_pathPrefix, actualFilename);

--- a/src/Corrade/TestSuite/Compare/File.h
+++ b/src/Corrade/TestSuite/Compare/File.h
@@ -42,7 +42,7 @@ namespace Compare { class File; }
 #ifndef DOXYGEN_GENERATING_OUTPUT
 template<> class CORRADE_TESTSUITE_EXPORT Comparator<Compare::File> {
     public:
-        explicit Comparator(const std::string& pathPrefix = {});
+        explicit Comparator(std::string  pathPrefix = {});
 
         bool operator()(const std::string& actualFilename, const std::string& expectedFilename);
 

--- a/src/Corrade/TestSuite/Tester.cpp
+++ b/src/Corrade/TestSuite/Tester.cpp
@@ -61,7 +61,7 @@ void Tester::registerArguments(int& argc, char** const argv) {
     _argv = argv;
 }
 
-Tester::Tester(const TesterConfiguration& configuration): _logOutput{nullptr}, _errorOutput{nullptr}, _testCaseLine{0}, _checkCount{0}, _expectedFailure{nullptr}, _configuration{configuration} {
+Tester::Tester(TesterConfiguration  configuration): _logOutput{nullptr}, _errorOutput{nullptr}, _testCaseLine{0}, _checkCount{0}, _expectedFailure{nullptr}, _configuration{std::move(configuration)} {
     CORRADE_ASSERT(_argc, "TestSuite::Tester: command-line arguments not available", );
 }
 

--- a/src/Corrade/TestSuite/Tester.h
+++ b/src/Corrade/TestSuite/Tester.h
@@ -542,7 +542,7 @@ class CORRADE_TESTSUITE_EXPORT Tester {
          * @brief Constructor
          * @param configuration     Optional configuration
          */
-        explicit Tester(const TesterConfiguration& configuration = TesterConfiguration{});
+        explicit Tester(TesterConfiguration  configuration = TesterConfiguration{});
 
         /**
          * @brief Add test cases

--- a/src/Corrade/Utility/Arguments.cpp
+++ b/src/Corrade/Utility/Arguments.cpp
@@ -99,7 +99,7 @@ std::vector<std::string> Arguments::environment() {
     /* Standard Unix and local Emscripten environment */
     #if defined(CORRADE_TARGET_UNIX) || defined(CORRADE_TARGET_EMSCRIPTEN)
     for(char** e = environ; *e; ++e)
-        list.push_back(*e);
+        list.emplace_back(*e);
 
     /* System environment provided by Node.js. Hopefully nobody uses \b in
        environment variables. (Can't use \0 because Emscripten chokes on it.) */

--- a/src/Corrade/Utility/Arguments.cpp
+++ b/src/Corrade/Utility/Arguments.cpp
@@ -141,7 +141,7 @@ std::vector<std::string> Arguments::environment() {
     return list;
 }
 
-Arguments::Arguments(std::string prefix): _prefix{prefix + '-'} {
+Arguments::Arguments(const std::string& prefix): _prefix{prefix + '-'} {
     /* Add help option */
     addBooleanOption("help");
     setHelp("help", "display this help message and exit");
@@ -335,7 +335,7 @@ bool Arguments::tryParse(const int argc, const char** const argv) {
     if(_command.empty() && argv && argc >= 1) _command = argv[0];
 
     /* Clear previously parsed values */
-    for(auto it = _booleans.begin(); it != _booleans.end(); ++it) *it = false;
+    for(auto && _boolean : _booleans) _boolean = false;
     for(const Entry& entry: _entries) {
         if(entry.type == Type::BooleanOption) continue;
 

--- a/src/Corrade/Utility/Arguments.h
+++ b/src/Corrade/Utility/Arguments.h
@@ -188,7 +188,7 @@ class CORRADE_UTILITY_EXPORT Arguments {
          * See class documentation for example.
          * @see @ref addSkippedPrefix()
          */
-        explicit Arguments(std::string prefix);
+        explicit Arguments(const std::string& prefix);
 
         ~Arguments();
 

--- a/src/Corrade/Utility/Configuration.cpp
+++ b/src/Corrade/Utility/Configuration.cpp
@@ -173,7 +173,7 @@ std::string Configuration::parse(std::istream& in, ConfigurationGroup* group, co
         if(buffer.empty()) {
             if(_flags & InternalFlag::SkipComments) continue;
 
-            group->_values.push_back(ConfigurationGroup::Value());
+            group->_values.emplace_back();
 
         /* Group header */
         } else if(buffer[0] == '[') {

--- a/src/Corrade/Utility/Configuration.cpp
+++ b/src/Corrade/Utility/Configuration.cpp
@@ -71,7 +71,7 @@ Configuration::Configuration(std::istream& in, const Flags flags): Configuration
     if(parse(in)) _flags |= InternalFlag::IsValid;
 }
 
-Configuration::Configuration(Configuration&& other): ConfigurationGroup(std::move(other)), _filename(std::move(other._filename)), _flags(std::move(other._flags)) {
+Configuration::Configuration(Configuration&& other): ConfigurationGroup(std::move(other)), _filename(std::move(other._filename)), _flags(other._flags) {
     /* Redirect configuration pointer to this instance */
     setConfigurationPointer(this);
 }
@@ -81,7 +81,7 @@ Configuration::~Configuration() { if(_flags & InternalFlag::Changed) save(); }
 Configuration& Configuration::operator=(Configuration&& other) {
     ConfigurationGroup::operator=(std::move(other));
     _filename = std::move(other._filename);
-    _flags = std::move(other._flags);
+    _flags = other._flags;
 
     /* Redirect configuration pointer to this instance */
     setConfigurationPointer(this);
@@ -291,46 +291,46 @@ void Configuration::save(std::ostream& out, const std::string& eol, Configuratio
     std::string buffer;
 
     /* Foreach all items in the group */
-    for(auto it = group->_values.cbegin(); it != group->_values.cend(); ++it) {
+    for(const auto & _value : group->_values) {
         /* Key/value pair */
-        if(!it->key.empty()) {
+        if(!_value.key.empty()) {
             /* Multi-line value */
-            if(it->value.find_first_of('\n') != std::string::npos) {
+            if(_value.value.find_first_of('\n') != std::string::npos) {
                 /* Replace \n with `eol` */
                 /** @todo fixme: ugly and slow */
-                std::string value = it->value;
+                std::string value = _value.value;
                 std::size_t pos = 0;
                 while((pos = value.find_first_of('\n', pos)) != std::string::npos) {
                     value.replace(pos, 1, eol);
                     pos += eol.size();
                 }
 
-                buffer = it->key + "=\"\"\"" + eol + value + eol + "\"\"\"" + eol;
+                buffer = _value.key + "=\"\"\"" + eol + value + eol + "\"\"\"" + eol;
 
             /* Value with leading/trailing spaces */
-            } else if(!it->value.empty() && (isWhitespace(it->value.front()) || isWhitespace(it->value.back()))) {
-                buffer = it->key + "=\"" + it->value + '"' + eol;
+            } else if(!_value.value.empty() && (isWhitespace(_value.value.front()) || isWhitespace(_value.value.back()))) {
+                buffer = _value.key + "=\"" + _value.value + '"' + eol;
 
             /* Value without spaces */
-            } else buffer = it->key + '=' + it->value + eol;
+            } else buffer = _value.key + '=' + _value.value + eol;
         }
 
         /* Comment / empty line */
-        else buffer = it->value + eol;
+        else buffer = _value.value + eol;
 
         out.write(buffer.data(), buffer.size());
     }
 
     /* Recursively process all subgroups */
-    for(auto git = group->_groups.cbegin(); git != group->_groups.cend(); ++git) {
+    for(const auto & _group : group->_groups) {
         /* Subgroup name */
-        std::string name = git->name;
+        std::string name = _group.name;
         if(!fullPath.empty()) name = fullPath + '/' + name;
 
         buffer = '[' + name + ']' + eol;
         out.write(buffer.data(), buffer.size());
 
-        save(out, eol, git->group, name);
+        save(out, eol, _group.group, name);
     }
 }
 

--- a/src/Corrade/Utility/ConfigurationGroup.cpp
+++ b/src/Corrade/Utility/ConfigurationGroup.cpp
@@ -36,29 +36,29 @@ ConfigurationGroup::ConfigurationGroup(Configuration* configuration): _configura
 
 ConfigurationGroup::ConfigurationGroup(const ConfigurationGroup& other): _values(other._values), _groups(other._groups), _configuration(nullptr) {
     /* Deep copy groups */
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        it->group = new ConfigurationGroup(*it->group);
+    for(auto & _group : _groups)
+        _group.group = new ConfigurationGroup(*_group.group);
 }
 
 ConfigurationGroup::ConfigurationGroup(ConfigurationGroup&& other): _values(std::move(other._values)), _groups(std::move(other._groups)), _configuration(nullptr) {
     /* Reset configuration pointer for subgroups */
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        it->group->_configuration = nullptr;
+    for(auto & _group : _groups)
+        _group.group->_configuration = nullptr;
 }
 
 ConfigurationGroup& ConfigurationGroup::operator=(const ConfigurationGroup& other) {
     /* Delete current groups */
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        delete it->group;
+    for(auto & _group : _groups)
+        delete _group.group;
 
     /* _configuration stays the same */
     _values = other._values;
     _groups = other._groups;
 
     /* Deep copy groups */
-    for(auto it = _groups.begin(); it != _groups.end(); ++it) {
-        it->group = new ConfigurationGroup(*it->group);
-        it->group->_configuration = _configuration;
+    for(auto & _group : _groups) {
+        _group.group = new ConfigurationGroup(*_group.group);
+        _group.group->_configuration = _configuration;
     }
 
     return *this;
@@ -66,23 +66,23 @@ ConfigurationGroup& ConfigurationGroup::operator=(const ConfigurationGroup& othe
 
 ConfigurationGroup& ConfigurationGroup::operator=(ConfigurationGroup&& other) {
     /* Delete current groups */
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        delete it->group;
+    for(auto & _group : _groups)
+        delete _group.group;
 
     /* _configuration stays the same */
     _values = std::move(other._values);
     _groups = std::move(other._groups);
 
     /* Redirect configuration pointer for subgroups */
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        it->group->_configuration = _configuration;
+    for(auto & _group : _groups)
+        _group.group->_configuration = _configuration;
 
     return *this;
 }
 
 ConfigurationGroup::~ConfigurationGroup() {
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        delete it->group;
+    for(auto & _group : _groups)
+        delete _group.group;
 }
 
 auto ConfigurationGroup::findGroup(const std::string& name, const unsigned int index) -> std::vector<Group>::iterator {
@@ -107,8 +107,8 @@ bool ConfigurationGroup::hasGroup(const std::string& name, const unsigned int in
 
 unsigned int ConfigurationGroup::groupCount(const std::string& name) const {
     unsigned int count = 0;
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        if(it->name == name) ++count;
+    for(const auto & _group : _groups)
+        if(_group.name == name) ++count;
 
     return count;
 }
@@ -126,8 +126,8 @@ const ConfigurationGroup* ConfigurationGroup::group(const std::string& name, uns
 std::vector<ConfigurationGroup*> ConfigurationGroup::groups(const std::string& name) {
     std::vector<ConfigurationGroup*> found;
 
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        if(it->name == name) found.push_back(it->group);
+    for(auto & _group : _groups)
+        if(_group.name == name) found.push_back(_group.group);
 
     return found;
 }
@@ -135,8 +135,8 @@ std::vector<ConfigurationGroup*> ConfigurationGroup::groups(const std::string& n
 std::vector<const ConfigurationGroup*> ConfigurationGroup::groups(const std::string& name) const {
     std::vector<const ConfigurationGroup*> found;
 
-    for(auto it = _groups.cbegin(); it != _groups.cend(); ++it)
-        if(it->name == name) found.push_back(it->group);
+    for(const auto & _group : _groups)
+        if(_group.name == name) found.push_back(_group.group);
 
     return found;
 }
@@ -212,16 +212,16 @@ auto ConfigurationGroup::findValue(const std::string& key, const unsigned int in
 }
 
 bool ConfigurationGroup::hasValues() const {
-    for(auto it = _values.cbegin(); it != _values.cend(); ++it)
-        if(!it->key.empty()) return true;
+    for(const auto & _value : _values)
+        if(!_value.key.empty()) return true;
 
     return false;
 }
 
 unsigned int ConfigurationGroup::valueCount() const {
     unsigned int count = 0;
-    for(auto it = _values.cbegin(); it != _values.cend(); ++it)
-        if(!it->key.empty()) ++count;
+    for(const auto & _value : _values)
+        if(!_value.key.empty()) ++count;
 
     return count;
 }
@@ -232,8 +232,8 @@ bool ConfigurationGroup::hasValue(const std::string& key, const unsigned int ind
 
 unsigned int ConfigurationGroup::valueCount(const std::string& key) const {
     unsigned int count = 0;
-    for(auto it = _values.cbegin(); it != _values.cend(); ++it)
-        if(it->key == key) ++count;
+    for(const auto & _value : _values)
+        if(_value.key == key) ++count;
 
     return count;
 }
@@ -246,8 +246,8 @@ std::string ConfigurationGroup::valueInternal(const std::string& key, const unsi
 std::vector<std::string> ConfigurationGroup::valuesInternal(const std::string& key, ConfigurationValueFlags) const {
     std::vector<std::string> found;
 
-    for(auto it = _values.cbegin(); it != _values.cend(); ++it)
-        if(it->key == key) found.push_back(it->value);
+    for(const auto & _value : _values)
+        if(_value.key == key) found.push_back(_value.value);
 
     return found;
 }
@@ -258,9 +258,9 @@ bool ConfigurationGroup::setValueInternal(const std::string& key, std::string va
         "Utility::ConfigurationGroup::setValue(): disallowed character in key", false);
 
     unsigned int foundIndex = 0;
-    for(auto it = _values.begin(); it != _values.end(); ++it) {
-        if(it->key == key && foundIndex++ == index) {
-            it->value = std::move(value);
+    for(auto & _value : _values) {
+        if(_value.key == key && foundIndex++ == index) {
+            _value.value = std::move(value);
             if(_configuration) _configuration->_flags |= Configuration::InternalFlag::Changed;
             return true;
         }
@@ -311,8 +311,8 @@ void ConfigurationGroup::removeAllValues(const std::string& key) {
 void ConfigurationGroup::clear() {
     _values.clear();
 
-    for(auto it = _groups.begin(); it != _groups.end(); ++it)
-        delete it->group;
+    for(auto & _group : _groups)
+        delete _group.group;
     _groups.clear();
 }
 

--- a/src/Corrade/Utility/ConfigurationValue.cpp
+++ b/src/Corrade/Utility/ConfigurationValue.cpp
@@ -49,7 +49,7 @@ namespace Implementation {
     }
 
     template<class T> T BasicConfigurationValue<T>::fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
-        std::string _stringValue = stringValue;
+        const std::string& _stringValue = stringValue;
 
         std::istringstream stream(_stringValue);
 

--- a/src/Corrade/Utility/Resource.cpp
+++ b/src/Corrade/Utility/Resource.cpp
@@ -178,7 +178,7 @@ std::string Resource::compileFrom(const std::string& name, const std::string& co
             Error() << "    Error: cannot open file" << filename << "of file" << fileData.size()+1 << "in group" << group;
             return {};
         }
-        fileData.emplace_back(std::move(alias), std::string{contents, contents.size()});
+        fileData.emplace_back(alias, std::string{contents, contents.size()});
     }
 
     return compile(name, group, fileData);


### PR DESCRIPTION
This is a minor commit that meticulously modernizes Corrade with the following changes:

1. No moving elements that are better simply copied
2. push_back -> emplace_back when appropriate
3. Use defaulted constructor/destructors, not trivial ones
4. Use more move friendly constructors
5. Remove unnecessary quantifiers / add ones where appropriate
6. Range-for for all

Feel free to take what you like and leave what you don't!