### PR TITLE
New CorradeMain library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ option(WITH_INTERCONNECT "Build Interconnect library" ON)
 option(WITH_PLUGINMANAGER "Build PluginManager library" ON)
 option(WITH_TESTSUITE "Build TestSuite library" ON)
 cmake_dependent_option(WITH_UTILITY "Build Utility library" ON "NOT WITH_INTERCONNECT;NOT WITH_PLUGINMANAGER;NOT WITH_TESTSUITE" ON)
+cmake_dependent_option(WITH_MAIN "Build Main library" ON "NOT WITH_TESTSUITE" ON)
 cmake_dependent_option(WITH_RC "Build the corrade-rc utility" ON "NOT WITH_UTILITY" ON)
 
 option(BUILD_DEPRECATED "Include deprecated API in the build" ON)

--- a/doc/00-page-order.dox
+++ b/doc/00-page-order.dox
@@ -30,6 +30,7 @@ namespace Corrade {
 /**
 @page building-corrade Downloading and building Corrade
 @page corrade-cmake Using Corrade with CMake
+@page main Corrade::Main library
 @page corrade-singles Single-header libraries
 @page corrade-example-index Examples
 @page corrade-rc Resource compiler

--- a/doc/corrade-changelog.dox
+++ b/doc/corrade-changelog.dox
@@ -37,6 +37,9 @@ namespace Corrade {
     which means there's a new (automatically enbaled) `MSVC2019_COMPATIBILITY`
     CMake option, exposed further as @ref CORRADE_MSVC2019_COMPATIBILITY CMake
     variable and preprocessor macro.
+-   New @ref main "Corrade::Main" library for improved user experience and
+    consistent behavior on Windows platforms (see
+    [mosra/corrade#37](https://github.com/mosra/corrade/pull/37))
 -   Added @ref CORRADE_TARGET_POWERPC for detecting PowerPC architectures (see
     [mosra/corrade#60](https://github.com/mosra/corrade/pull/60))
 -   New set of @ref CORRADE_TARGET_LIBCXX, @ref CORRADE_TARGET_LIBSTDCXX and

--- a/doc/corrade-cmake.dox
+++ b/doc/corrade-cmake.dox
@@ -191,7 +191,8 @@ corrade_add_test(<test name>
 
 Test name is also executable name. You can use `LIBRARIES` to specify libraries
 to link with instead of using @cmake target_link_libraries() @ce. The
-`Corrade::TestSuite` target is linked automatically to each test. Note that the
+`Corrade::TestSuite` target is linked automatically to each test, together with
+@ref main "Corrade::Main" for improved experience on Windows. Note that the
 @cmake enable_testing() @ce function must be called explicitly. Arguments
 passed after `ARGUMENTS` will be appended to the test command line. `ARGUMENTS`
 are supported everywhere except when @ref CORRADE_TESTSUITE_TARGET_XCTEST is

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -1,0 +1,127 @@
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+namespace Corrade {
+
+/** @page main Corrade::Main library
+@brief Improves general user experience on Windows.
+
+This library is built if `WITH_MAIN` is enabled when building Corrade. To use
+this library with CMake, you need to request the `Main` component of the
+`Corrade` package and link *your application executable* to the `Corrade::Main`
+target:
+
+@code{.cmake}
+find_package(Corrade REQUIRED Main)
+
+add_executable(your-app WIN32 main.cpp) # use WIN32 to hide the console window
+target_link_libraries(your-app PRIVATE Corrade::Main)
+@endcode
+
+See also @ref building-corrade and @ref corrade-cmake for more information.
+
+@m_class{m-block m-success}
+
+@par Corrade::Main on non-Windows systems
+    If you're not on Windows, congratulations. Your system is great and there's
+    no need for any sanity-restoring countermeasures. Linking to `Corrade::Main`
+    via CMake on such systems is a no-op.
+
+If you're on Windows, linking to the `Corrade::Main` library does the
+following:
+
+-   allows you to always use the standard @cpp main() @ce (instead of
+    @cpp _tmain() @ce, @cpp wWinMain() @ce and other atrocities)
+-   makes it possible to create executables with @cmake add_executable(... WIN32 ...) @ce
+    and hide the console window again without requiring you to do any sad
+    things to your main function
+-   gives you @cpp char** argv @ce in UTF-8, converting them from
+    Windows-specific wide-char APIs
+-   sets up console output to be in UTF-8 as well, so special characters and
+    non-ASCII alphabets display correctly
+-   if @ref CORRADE_UTILITY_USE_ANSI_COLORS is enabled, enables processing of
+    ANSI escape codes in the console, so @ref Utility::Debug colored output and
+    other advanced terminal features work properly
+
+@section main-utf8-arguments Standard main() with UTF-8 command-line arguments
+
+When you link to Corrade Main, you can keep using the standard
+@cpp int main(int argc, char** argv) @ce as you would do on Unix systems and
+you get the @p argv in UTF-8. The library does this by providing a "shim"
+@cpp wmain() @ce / @cpp wWinMain() @ce, converting the wide-char `argv` to
+UTF-8 and then passing that to your standard @cpp main() @ce.
+
+@section main-winmain WIN32 apps without console window lurking in the background
+
+Executables created with @cmake add_executable(... WIN32 ...) @ce "just work"
+and there's no console window lurking in the background anymore. Nevertheless,
+you still get UTF-8 encoded `argc` / `argv` in your usual @cpp main() @ce.
+Standard output isn't captured anywhere by default, for debugging purposes you
+can either temporarily remove the `WIN32` option and rebuild or use console
+redirection (@cb{.bat} app.exe > stdout.txt @ce and
+@cb{.bat} app.exe 2> stderr.txt @ce works as expected).
+
+@section main-ansi-colors ANSI colors in console output
+
+By default, for compatibility reasons, Corrade is built with the
+@ref corrade-cmake "CMake option" `UTILITY_USE_ANSI_COLORS` disabled, meaning
+colored output is done through direct WINAPI calls only when writing directly
+to the console. Those APIs provide only a limited subset of the ANSI escape
+code feature set and stop working as soon as you redirect the output to a file
+or a pipe.
+
+With the @ref CORRADE_UTILITY_USE_ANSI_COLORS option enabled, the colored
+output is printed the same way as on Unix terminals. Recent versions of Windows
+10 support that natively, however it's needed to enable this feature explicitly
+in the console that's running the application by passing
+`ENABLE_VIRTUAL_TERMINAL_PROCESSING` to
+@m_class{m-doc-external} [SetConsoleMode()](https://docs.microsoft.com/en-us/windows/console/setconsolemode).
+The Corrade Main library does that in the @cpp wmain() @ce / @cpp wWinMain() @ce
+shim.
+
+@section main-utf8-output UTF-8 console otuput encoding
+
+With Corrade being designed in a way that UTF-8 is the standard encoding, it
+makes sense to have the console output encoding set to UTF-8 as well. Corrade
+Main does that by calling @m_class{m-doc-external} [SetConsoleOutputCP()](https://docs.microsoft.com/en-us/windows/console/setconsoleoutputcp)
+with `CP_UTF8` in the @cpp wmain() @ce / @cpp wWinMain() @ce shim.
+
+@section main-non-cmake Usage without CMake
+
+When you don't use CMake, simply linking to the `CorradeMain.lib` is not enough
+to achieve the desired effect --- additionally you need to tell the linker to
+choose a different entry point. That's done by passing `/ENTRY:wmainCRTStartup`
+to it for console apps and `/ENTRY:wWinMainCRTStartup` for GUI apps.
+
+@m_class{m-block m-warning}
+
+@par Entry point specification with MinGW
+    Unfortunately, the `/ENTRY` option is not recognized by MinGW and there you
+    need to pass `-municode` instead, regardless of whether the app is console
+    or GUI.
+
+*/
+
+}

--- a/modules/UseCorrade.cmake
+++ b/modules/UseCorrade.cmake
@@ -337,6 +337,7 @@ function(corrade_add_test test_name)
     if(CORRADE_TESTSUITE_TARGET_XCTEST)
         add_library(${test_name} SHARED ${sources})
         set_target_properties(${test_name} PROPERTIES FRAMEWORK TRUE)
+        # This never Windows, so no need to bother with Corrade::Main
         target_link_libraries(${test_name} PRIVATE ${libraries} Corrade::TestSuite)
 
         set(test_runner_file ${CMAKE_CURRENT_BINARY_DIR}/${test_name}.mm)
@@ -356,7 +357,7 @@ function(corrade_add_test test_name)
         endif()
     else()
         add_executable(${test_name} ${sources})
-        target_link_libraries(${test_name} PRIVATE ${libraries} Corrade::TestSuite)
+        target_link_libraries(${test_name} PRIVATE ${libraries} Corrade::TestSuite Corrade::Main)
 
         # Run tests using Node.js on Emscripten
         if(CORRADE_TARGET_EMSCRIPTEN)

--- a/package/ci/appveyor-desktop-mingw.bat
+++ b/package/ci/appveyor-desktop-mingw.bat
@@ -19,10 +19,13 @@ cd %APPVEYOR_BUILD_FOLDER%/build || exit /b
 set CORRADE_TEST_COLOR=ON
 ctest -V || exit /b
 
-rem Examples
+rem Examples. The --coverage flag needs to be specified as well otherwise
+rem linking to CorradeMain will result in undefined reference to __gcov_init
+rem and such.
 cd %APPVEYOR_BUILD_FOLDER% || exit /b
 mkdir build-examples && cd build-examples || exit /b
 cmake ../src/examples ^
+    -DCMAKE_CXX_FLAGS="--coverage" ^
     -DCMAKE_BUILD_TYPE=Debug ^
     -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%/deps ^
     -G Ninja || exit /b

--- a/src/Corrade/CMakeLists.txt
+++ b/src/Corrade/CMakeLists.txt
@@ -72,5 +72,44 @@ if(BUILD_TESTS)
     add_subdirectory(Test)
 endif()
 
+if(WITH_MAIN)
+    if(CORRADE_TARGET_WINDOWS)
+        add_library(CorradeMain STATIC CorradeMain.cpp)
+        target_include_directories(CorradeMain PUBLIC
+            ${PROJECT_SOURCE_DIR}/src
+            ${PROJECT_BINARY_DIR}/src)
+        set_property(TARGET CorradeMain PROPERTY
+            INTERFACE_CORRADE_CXX_STANDARD 11) # TODO: interface, really?
+        set_property(TARGET CorradeMain APPEND PROPERTY
+            COMPATIBLE_INTERFACE_NUMBER_MAX CORRADE_CXX_STANDARD)
+        set_target_properties(CorradeMain PROPERTIES DEBUG_POSTFIX "-d")
+        if(NOT MINGW)
+            # Abusing INTERFACE_LINK_LIBRARIES because INTERFACE_LINK_OPTIONS
+            # is only since 3.13. They treat things with `-` in front as linker
+            # flags and fortunately I can use `-ENTRY` instead of `/ENTRY`.
+            # https://gitlab.kitware.com/cmake/cmake/issues/16543
+            set_property(TARGET CorradeMain APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES "-ENTRY:$<$<NOT:$<BOOL:$<TARGET_PROPERTY:WIN32_EXECUTABLE>>>:wmainCRTStartup>$<$<BOOL:$<TARGET_PROPERTY:WIN32_EXECUTABLE>>:wWinMainCRTStartup>")
+        else()
+            set_property(TARGET CorradeMain APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES "-municode")
+        endif()
+        install(TARGETS CorradeMain
+            RUNTIME DESTINATION ${CORRADE_BINARY_INSTALL_DIR}
+            LIBRARY DESTINATION ${CORRADE_LIBRARY_INSTALL_DIR}
+            ARCHIVE DESTINATION ${CORRADE_LIBRARY_INSTALL_DIR})
+
+    # On sane system it's just a dummy interface target
+    else()
+        add_library(CorradeMain INTERFACE)
+        target_include_directories(CorradeMain INTERFACE
+            ${PROJECT_SOURCE_DIR}/src
+            ${PROJECT_BINARY_DIR}/src)
+    endif()
+
+    # Corrade::Main target alias for superprojects
+    add_library(Corrade::Main ALIAS CorradeMain)
+endif()
+
 # Corrade configure file for superprojects
 set(_CORRADE_CONFIGURE_FILE ${CMAKE_CURRENT_BINARY_DIR}/configure.h CACHE INTERNAL "")

--- a/src/Corrade/Corrade.h
+++ b/src/Corrade/Corrade.h
@@ -300,6 +300,10 @@ escape sequences are supported only on Windows 10 or when using non-standard
 console emulators. Available only on Windows, all other platforms use ANSI
 sequences implicitly. Enabled using `UTILITY_USE_ANSI_COLORS` CMake option when
 building Corrade.
+
+Note that on Windows 10 you need to additionally enable ANSI color support in
+the console. This is done automatically when you link to the
+@ref main "Corrade Main library".
 @see @ref CORRADE_TARGET_WINDOWS, @ref building-corrade, @ref corrade-cmake
 */
 #define CORRADE_UTILITY_USE_ANSI_COLORS

--- a/src/Corrade/CorradeMain.cpp
+++ b/src/Corrade/CorradeMain.cpp
@@ -1,0 +1,124 @@
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Corrade/configure.h"
+
+#ifdef CORRADE_TARGET_WINDOWS
+#include <cstdint>
+
+/* Use Array, but in a way that doesn't require the whole Utility library
+   to be linked */
+#define CORRADE_NO_DEBUG
+#define CORRADE_NO_ASSERT
+#include "Corrade/Containers/Array.h"
+
+#define WIN32_LEAN_AND_MEAN 1
+#define VC_EXTRALEAN
+#include <windows.h>
+
+/* Not defined by MinGW at least. Taken from
+   https://docs.microsoft.com/en-us/windows/console/setconsolemode */
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+
+using namespace Corrade;
+
+namespace {
+
+Containers::Array<char*> convertWideArgv(std::size_t argc, wchar_t** wargv, Containers::Array<char>& storage) {
+    /* Calculate total length of all arguments, save the relative offsets */
+    Containers::Array<char*> argv{Containers::ValueInit, argc + 1};
+    std::size_t totalSize = 0;
+    for(std::size_t i = 0; i != argc; ++i) {
+        totalSize += WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, nullptr, 0, nullptr, nullptr);
+        argv[i + 1] = static_cast<char*>(nullptr) + totalSize;
+    }
+
+    /* Allocate the argument array, make the relative offsets absolute */
+    storage = Containers::Array<char>{totalSize};
+    for(std::size_t i = 0; i != argv.size(); ++i)
+        argv[i] += storage.data() - static_cast<char*>(nullptr);
+
+    /* Convert the arguments to sane UTF-8 */
+    for(std::size_t i = 0; i != argc; ++i)
+        WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, argv[i], argv[i + 1] - argv[i], nullptr, nullptr);
+
+    return argv;
+}
+
+}
+
+extern "C" int main(int, char**);
+
+/* extern "C" needed for MinGW -- https://sourceforge.net/p/mingw-w64/wiki2/Unicode%20apps/ */
+extern "C" int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int);
+extern "C" int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
+    /* Convert argv to UTF-8. We have __wargv, no need to use
+       CommandLineToArgvW(). */
+    Containers::Array<char> storage;
+    #ifdef __MINGW32__
+    /* Disable "warning: ISO C++ forbids taking address of function '::main'",
+       the main() is mine, doesn't have any automatic constructors or anything
+       attached and I know what I am doing here. */
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wpedantic"
+    #endif
+    return main(__argc, convertWideArgv(__argc, __wargv, storage).data());
+    #ifdef __MINGW32__
+    #pragma GCC diagnostic pop
+    #endif
+}
+
+extern "C" int wmain(int, wchar_t**);
+extern "C" int wmain(int argc, wchar_t** wargv) {
+    /* Set output to UTF-8 */
+    SetConsoleOutputCP(CP_UTF8);
+
+    #ifdef CORRADE_UTILITY_USE_ANSI_COLORS
+    /* Enable ANSI color handling in the console */
+    HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD currentConsoleMode;
+    if(out != INVALID_HANDLE_VALUE && GetConsoleMode(out, &currentConsoleMode))
+        SetConsoleMode(out, currentConsoleMode|ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+    #endif
+
+    /* Convert argv to UTF-8 */
+    Containers::Array<char> storage;
+    #ifdef __MINGW32__
+    /* Disable "warning: ISO C++ forbids taking address of function '::main'",
+       the main() is mine, doesn't have any automatic constructors or anything
+       attached and I know what I am doing here. */
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wpedantic"
+    #endif
+    return main(argc, convertWideArgv(argc, wargv, storage).data());
+    #ifdef __MINGW32__
+    #pragma GCC diagnostic pop
+    #endif
+}
+#else
+#error this file is needed only on Windows
+#endif

--- a/src/Corrade/Test/CMakeLists.txt
+++ b/src/Corrade/Test/CMakeLists.txt
@@ -23,6 +23,8 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
+corrade_add_test(MainTest MainTest.cpp
+    ARGUMENTS --arg-utf hýždě --arg-another šňůra)
 corrade_add_test(TargetTest TargetTest.cpp)
 
 # Baseline, C++11, is everywhere

--- a/src/Corrade/Test/MainTest.cpp
+++ b/src/Corrade/Test/MainTest.cpp
@@ -1,0 +1,88 @@
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <vector>
+#include <string>
+
+#include "Corrade/Containers/Array.h"
+#include "Corrade/TestSuite/Tester.h"
+#include "Corrade/TestSuite/Compare/Container.h"
+#include "Corrade/Utility/DebugStl.h"
+
+namespace Corrade { namespace Test { namespace {
+
+struct MainTest: TestSuite::Tester {
+    explicit MainTest();
+
+    void utf8output();
+    void colors();
+    void arguments();
+};
+
+MainTest::MainTest(): TestSuite::Tester{TesterConfiguration{}.setSkippedArgumentPrefixes({"arg"})} {
+    addTests({&MainTest::utf8output,
+              &MainTest::colors,
+              &MainTest::arguments});
+}
+
+void MainTest::utf8output() {
+    Debug{} << "The lines below should have the same length, one with diacritics:";
+    Debug{} << "hýždě šňůra";
+    Debug{} << "hyzde snura";
+
+    CORRADE_VERIFY(true);
+}
+
+void MainTest::colors() {
+    #ifdef CORRADE_TARGET_WINDOWS
+    #ifndef CORRADE_UTILITY_USE_ANSI_COLORS
+    Debug{} << "CORRADE_UTILITY_USE_ANSI_COLORS not set, using WinAPI instead";
+    #else
+    Debug{} << "CORRADE_UTILITY_USE_ANSI_COLORS set";
+    #endif
+    #endif
+    Debug{} << "Visual check:" << Debug::boldColor(Debug::Color::Blue) << "this is blue!" << Debug::resetColor << "and this is a grey square:" << Debug::color << std::uint8_t(0x77);
+
+    CORRADE_VERIFY(true);
+}
+
+void MainTest::arguments() {
+    #ifdef CORRADE_TESTSUITE_TARGET_XCTEST
+    CORRADE_SKIP("Command-line arguments are currently ignored under XCTest.");
+    #endif
+    Debug{} << "Arguments expected: {--arg-utf, hýždě, --arg-another, šňůra}";
+    Debug{} << "Arguments passed:  " << Containers::arrayView(
+        Tester::arguments().second, Tester::arguments().first).suffix(1);
+
+    CORRADE_COMPARE_AS((std::vector<std::string>{
+        Tester::arguments().second + 1, Tester::arguments().second + Tester::arguments().first}),
+        (std::vector<std::string>{"--arg-utf", "hýždě", "--arg-another", "šňůra"
+        }),
+        TestSuite::Compare::Container);
+}
+
+}}}
+
+CORRADE_TEST_MAIN(Corrade::Test::MainTest)

--- a/src/Corrade/TestSuite/Tester.h
+++ b/src/Corrade/TestSuite/Tester.h
@@ -363,6 +363,9 @@ it and adds it to CTest. Besides that it is able to link other arbitrary
 libraries to the executable and specify a list of files that the tests used. It
 provides additional useful features on various platforms:
 
+-   On Windows, the macro links the test executable to the @ref main "Corrade::Main"
+    library for ANSI color support, UTF-8 argument parsing and UTF-8 output
+    encoding.
 -   If compiling for Emscripten, using @ref corrade-cmake-add-test "corrade_add_test()"
     makes CTest run the resulting `*.js` file via Node.js. Also it is able to
     bundle all files specified in `FILES` into the virtual Emscripten

--- a/src/Corrade/Utility/Debug.h
+++ b/src/Corrade/Utility/Debug.h
@@ -130,6 +130,11 @@ documentation for more information.
 
 @include UtilityDebug-color-greyscale.ansi
 
+@section Utility-Debug-windows ANSI color support and UTF-8 output on Windows
+
+See the @ref main "Corrade::Main" library for more information about a
+convenient way to support ANSI colors and UTF-8 output encoding on Windows.
+
 @section Utility-Debug-multithreading Thread safety
 
 If Corrade is compiled with @ref CORRADE_BUILD_MULTITHREADED enabled (the


### PR DESCRIPTION
A small wrapper that provides sane `main()` on Windows. Features / TODO:

- [x] Parse command-line arguments as UTF-16 in `_wmain()` and provide them the user in the usual `main()` as usual `argc` / `argv` parameters in the usual `main()`
- [x] Use `WinMain` so it's possible to hide that damn console window for GUI apps (but still expose `main()`)
- [x] Set up some environment so it's possible to use ANSI color escape codes on Win10 console (`ENABLE_VIRTUAL_TERMINAL_PROCESSING`, https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences)
- [x] Set output encoding to UTF-8 ~~(and restore after)~~ -- https://github.com/dart-lang/sdk/commit/92b746cd439d94a0ffea7f8bf45669c407acdc96#diff-5c4ad2f03f9aac0f124bf4e6dba66156 (restoring not needed, i assume it gets done automatically on process exit)
- [x] ~~Detection of `cmd.exe` vs `bash.exe`? https://arvid.io/2017/04/23/is-my-process-running-from-bash-exe-or-cmd-exe/~~ obsolete, ANSI works everywhere now
- [x] Documentation
- [x] Tests