### PR TITLE
TestSuite: multi-line string diff support

### DIFF
--- a/doc/corrade-changelog.dox
+++ b/doc/corrade-changelog.dox
@@ -137,6 +137,8 @@ namespace Corrade {
     testing
 -   New @ref TestSuite::Compare::NotEqual comparator to provide an alternative
     to @cpp CORRADE_VERIFY(a != b) @ce with a better failure diagnostic
+-   New @ref TestSuite::Compare::String comparator that prints a colored
+    line diff on failure (see also [mosra/corrade#38](https://github.com/mosra/corrade/pull/38))
 -   New @ref TestSuite::Compare::StringHasPrefix,
     @relativeref{TestSuite::Compare,StringHasSuffix},
     @relativeref{TestSuite::Compare,StringContains} and

--- a/doc/corrade-changelog.dox
+++ b/doc/corrade-changelog.dox
@@ -170,6 +170,8 @@ namespace Corrade {
 -   @ref Utility::ConfigurationGroup gained an ability to iterate through its
     values and subgroups using @relativeref{Utility::ConfigurationGroup,values()}
     and @relativeref{Utility::ConfigurationGroup,groups()}
+-   New @ref Utility::Debug::invertedColor() output modifier for printing
+    colored text with the foreground and background colors inverted
 -   New @ref Corrade::Utility::Json class for tokenizing and parsing JSON files
     into an immutable memory-efficient representation
 -   New @ref Corrade::Utility::JsonWriter class for stream-like writing and

--- a/doc/snippets/CMakeLists.txt
+++ b/doc/snippets/CMakeLists.txt
@@ -138,6 +138,7 @@ if(CORRADE_WITH_TESTSUITE AND NOT CORRADE_TARGET_IOS)
     add_executable(testsuite-benchmark ${EXCLUDE_FROM_ALL_IF_TEST_TARGET} testsuite-benchmark.cpp)
     add_executable(testsuite-benchmark-custom ${EXCLUDE_FROM_ALL_IF_TEST_TARGET} testsuite-benchmark-custom.cpp)
     add_executable(testsuite-description-source-location ${EXCLUDE_FROM_ALL_IF_TEST_TARGET} testsuite-description-source-location.cpp)
+    add_executable(testsuite-compare-string ${EXCLUDE_FROM_ALL_IF_TEST_TARGET} testsuite-compare-string.cpp)
 
     target_link_libraries(testsuite-basic PUBLIC CorradeTestSuite)
     target_link_libraries(testsuite-templated PUBLIC CorradeTestSuite)
@@ -148,6 +149,7 @@ if(CORRADE_WITH_TESTSUITE AND NOT CORRADE_TARGET_IOS)
     target_link_libraries(testsuite-benchmark PUBLIC CorradeTestSuite)
     target_link_libraries(testsuite-benchmark-custom PUBLIC CorradeTestSuite)
     target_link_libraries(testsuite-description-source-location PUBLIC CorradeTestSuite)
+    target_link_libraries(testsuite-compare-string PUBLIC CorradeTestSuite)
 
     if(CORRADE_TARGET_EMSCRIPTEN)
         # Wasn't a problem for Emscripten <= 2.0.13 and isn't a problem for
@@ -163,6 +165,7 @@ if(CORRADE_WITH_TESTSUITE AND NOT CORRADE_TARGET_IOS)
             testsuite-benchmark
             testsuite-benchmark-custom
             testsuite-description-source-location
+            testsuite-compare-string
             APPEND_STRING PROPERTY LINK_FLAGS " -s DISABLE_EXCEPTION_CATCHING=0")
     endif()
 
@@ -176,7 +179,8 @@ if(CORRADE_WITH_TESTSUITE AND NOT CORRADE_TARGET_IOS)
             testsuite-iteration
             testsuite-benchmark
             testsuite-benchmark-custom
-            testsuite-description-source-location)
+            testsuite-description-source-location
+            testsuite-compare-string)
     endif()
 endif()
 

--- a/doc/snippets/testsuite-compare-string.ansi
+++ b/doc/snippets/testsuite-compare-string.ansi
@@ -1,0 +1,11 @@
+[0;1;39mStarting ChatbotTest with 1 test cases...[0m
+[0;1;31m  FAIL[0;34m [[0;1;36m1[0;34m][0;1;39m greeting()[0m at …/testsuite-compare-string.cpp:57
+        Strings chatbot.greet() and "Hello!\n" "I'm Marvin.\n" "I'm here to answer your questions.\n" "Let's get started." are different.[0;32m Actual (+)[0m vs[0;31m expected (-)[0m:
+        Hello!
+        I'm Marvin.
+[0;31m       -I'm here to answer your questions.[0m
+[0;32m       +I'm here to question your answers.[0m
+        Let's get started.
+[0;32m       +You're not here to tell me what to do.[0m
+[0;32m       +I am.[0m
+[0;1;39mFinished ChatbotTest with[0;1;31m 1 errors[0;1;39m out of 1 checks.[0m

--- a/doc/snippets/testsuite-compare-string.ansi
+++ b/doc/snippets/testsuite-compare-string.ansi
@@ -3,8 +3,8 @@
         Strings chatbot.greet() and "Hello!\n" "I'm Marvin.\n" "I'm here to answer your questions.\n" "Let's get started." are different.[0;32m Actual (+)[0m vs[0;31m expected (-)[0m:
         Hello!
         I'm Marvin.
-[0;31m       -I'm here to answer your questions.[0m
-[0;32m       +I'm here to question your answers.[0m
+[0;31m       -[0;7;31m[0;31mI'm here to [0m[0;7;31manswer your [0;31mquestion[0m[0;7;31m[0;31ms.[0m[0;7;31m[0;31m[0m
+[0;32m       +[0;7;32m[0;32mI'm here to [0m[0;7;32m[0;32mquestion[0m[0;7;32m your answer[0;32ms.[0m[0;7;32m[0;32m[0m
         Let's get started.
 [0;32m       +You're not here to tell me what to do.[0m
 [0;32m       +I am.[0m

--- a/doc/snippets/testsuite-compare-string.cpp
+++ b/doc/snippets/testsuite-compare-string.cpp
@@ -1,0 +1,66 @@
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Corrade/Containers/StringView.h"
+#include "Corrade/TestSuite/Tester.h"
+#include "Corrade/TestSuite/Compare/String.h"
+
+using namespace Corrade;
+
+struct ChatbotTest: TestSuite::Tester {
+    explicit ChatbotTest();
+
+    void greeting();
+};
+
+ChatbotTest::ChatbotTest() {
+    addTests({&ChatbotTest::greeting});
+}
+
+void ChatbotTest::greeting() {
+    struct {
+        Containers::StringView greet() {
+            return
+                "Hello!\n"
+                "I'm Marvin.\n"
+                "I'm here to question your answers.\n"
+                "Let's get started.\n"
+                "You're not here to tell me what to do.\n"
+                "I am.";
+        }
+    } chatbot;
+
+/** [0] */
+CORRADE_COMPARE_AS(chatbot.greet(),
+    "Hello!\n"
+    "I'm Marvin.\n"
+    "I'm here to answer your questions.\n"
+    "Let's get started.",
+    TestSuite::Compare::String);
+/** [0] */
+}
+
+CORRADE_TEST_MAIN(ChatbotTest)

--- a/src/Corrade/TestSuite/Compare/Implementation/Diff.h
+++ b/src/Corrade/TestSuite/Compare/Implementation/Diff.h
@@ -1,0 +1,125 @@
+#ifndef Corrade_TestSuite_Compare_Implementation_Diff_h
+#define Corrade_TestSuite_Compare_Implementation_Diff_h
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <cstring>
+
+#include "Corrade/Containers/Array.h"
+#include "Corrade/Containers/GrowableArray.h"
+#include "Corrade/Containers/StridedArrayView.h"
+#include "Corrade/Containers/Triple.h"
+
+namespace Corrade { namespace TestSuite { namespace Compare { namespace Implementation {
+
+/* A simple diff algorithm from https://pynash.org/2013/02/26/diff-in-50-lines/
+   which is a trimmed-down implementation used by Python's difflib, which is
+   then an implementation of the Hunt–McIlroy algorithm listed on Wikipedia:
+   https://en.wikipedia.org/wiki/Hunt%E2%80%93Szymanski_algorithm
+
+   Done in a generic way to allow diffs on arbitrary types, not just lines of
+   text.
+
+   The complexity seems to be something like `O(mn log m)` where `m` is size
+   of the first input and `n` size of the second input. I'm not sure if the
+   Hunt–Szymanski optimization as explained on Wikipedia are present here,
+   nevertheless this should be ~okay as the use in TestSuite is only when a
+   comparison fails, which should be pretty rare. */
+/** @todo investigate the complexity if/when this becomes a public API */
+
+template<class T> Containers::Triple<std::size_t, std::size_t, std::size_t> longestMatchingSlice(const Containers::StridedArrayView1D<const T>& a, const Containers::StridedArrayView1D<const T>& b) {
+    std::size_t startA = 0;
+    std::size_t startB = 0;
+    std::size_t longestSize = 0;
+
+    /* A "map" of previous longest runs for each element -- in each iteration,
+       `runs[j]` is the length of longest match ending with `a[i - 1]` and
+       `b[j]`. Initially, there are no runs */
+    Containers::Array<std::size_t> runs{ValueInit, b.size()};
+    /* New runs collected in each iteration. Gets cleared at the start of every
+       iteration and swapped with `runs` at the end of every iteration, done
+       this way to avoid temporary allocations inside the loop. */
+    Containers::Array<std::size_t> newRuns{NoInit, b.size()};
+    /** @todo might want to pass some "scratch memory" from outside, so this
+        doesn't allocate at all (or just wait for allocators?) */
+
+    /* Go through all elements of A */
+    for(std::size_t i = 0; i != a.size(); ++i) {
+        /* Start with no active runs */
+        /** @todo Utility::fill(), finally */
+        std::memset(newRuns, 0, newRuns.size()*sizeof(std::size_t));
+
+        /* Go through all elements of B */
+        for(std::size_t j = 0; j != b.size(); ++j) {
+            if(a[i] != b[j]) continue;
+
+            /* If elements match, extend the previous line with them */
+            const std::size_t runSize = newRuns[j] = (j ? runs[j - 1] : 0) + 1;
+
+            /* If the run is longer than the current longest, update */
+            if(runSize > longestSize) {
+                startA = i - runSize + 1;
+                startB = j - runSize + 1;
+                longestSize = runSize;
+            }
+        }
+
+        /* Save the new runs == discard all previously-active runs that didn't
+           get extended in this iteration */
+        std::swap(runs, newRuns);
+    }
+
+    return {startA, startB, longestSize};
+}
+
+template<class T> void matchingSlicesInto(Containers::Array<Containers::Triple<std::size_t, std::size_t, std::size_t>>& out, const Containers::StridedArrayView1D<const T>& a, const std::size_t aOffset, const Containers::StridedArrayView1D<const T>& b, const std::size_t bOffset) {
+    /* Find the largest matching slice */
+    const Containers::Triple<std::size_t, std::size_t, std::size_t> longest = longestMatchingSlice(a, b);
+
+    /* If the ranges don't have anything in common, return without adding
+       anything to the output */
+    if(!longest.third())
+        return;
+
+    /* Recurse to find the largest matching slices before and after this one
+       (if there's anything left), put them to the output in order */
+    matchingSlicesInto(out,
+        a.prefix(longest.first()), aOffset,
+        b.prefix(longest.second()), bOffset);
+    arrayAppend(out, InPlaceInit,
+        longest.first() + aOffset,
+        longest.second() + bOffset,
+        longest.third());
+    matchingSlicesInto(out,
+        a.exceptPrefix(longest.first() + longest.third()),
+                aOffset + longest.first() + longest.third(),
+        b.exceptPrefix(longest.second() + longest.third()),
+                bOffset + longest.second() + longest.third());
+}
+
+}}}}
+
+#endif

--- a/src/Corrade/TestSuite/Compare/String.h
+++ b/src/Corrade/TestSuite/Compare/String.h
@@ -48,7 +48,9 @@ namespace Compare {
 @m_since_latest
 
 Compares the two strings, printing a line-by-line difference in case they are
-not the same. Example usage and a potential output:
+not the same, highlighting also changed line portions in case a difference
+between two standalone lines is less than a half of their size. Example usage
+and a potential output:
 
 @m_class{m-code-figure}
 

--- a/src/Corrade/TestSuite/Compare/String.h
+++ b/src/Corrade/TestSuite/Compare/String.h
@@ -44,6 +44,33 @@ namespace Corrade { namespace TestSuite {
 namespace Compare {
 
 /**
+@brief Pseudo-type for comparing two strings
+@m_since_latest
+
+Compares the two strings, printing a line-by-line difference in case they are
+not the same. Example usage and a potential output:
+
+@m_class{m-code-figure}
+
+@parblock
+
+@snippet testsuite-compare-string.cpp 0
+
+<b></b>
+
+@m_class{m-nopad m-console-wrap}
+
+@include testsuite-compare-string.ansi
+
+@endparblock
+
+See @ref TestSuite-Comparator-pseudo-types for more information.
+@see @ref StringHasPrefix, @ref StringHasSuffix, @ref StringContains,
+    @ref StringNotContains
+*/
+class String {};
+
+/**
 @brief Pseudo-type for verifying that a string has given prefix
 @m_since_latest
 
@@ -57,7 +84,8 @@ If the `--verbose` @ref TestSuite-Tester-command-line "command-line option" is
 specified, passed comparisons where the strings are different will print an
 @cb{.ansi} [1;39mINFO @ce message with the full string content for detailed
 inspection.
-@see @ref StringHasSuffix, @ref StringContains, @ref StringNotContains
+@see @ref StringHasSuffix, @ref StringContains, @ref StringNotContains,
+    @ref String
 */
 class StringHasPrefix {};
 
@@ -75,7 +103,8 @@ If the `--verbose` @ref TestSuite-Tester-command-line "command-line option" is
 specified, passed comparisons where the strings are different will print an
 @cb{.ansi} [1;39mINFO @ce message with the full string content for detailed
 inspection.
-@see @ref StringHasPrefix, @ref StringContains, @ref StringNotContains
+@see @ref StringHasPrefix, @ref StringContains, @ref StringNotContains,
+    @ref String
 */
 class StringHasSuffix {};
 
@@ -93,7 +122,8 @@ If the `--verbose` @ref TestSuite-Tester-command-line "command-line option" is
 specified, passed comparisons where the strings are different will print an
 @cb{.ansi} [1;39mINFO @ce message with the full string content for detailed
 inspection.
-@see @ref StringNotContains, @ref StringHasPrefix, @ref StringHasSuffix
+@see @ref StringNotContains, @ref StringHasPrefix, @ref StringHasSuffix,
+    @ref String
 */
 class StringContains {};
 
@@ -111,13 +141,25 @@ If the `--verbose` @ref TestSuite-Tester-command-line "command-line option" is
 specified, passed comparisons where the strings are different will print an
 @cb{.ansi} [1;39mINFO @ce message with the full string content for detailed
 inspection.
-@see @ref StringContains, @ref StringHasPrefix, @ref StringHasSuffix
+@see @ref StringContains, @ref StringHasPrefix, @ref StringHasSuffix,
+    @ref String
 */
 class StringNotContains {};
 
 }
 
 #ifndef DOXYGEN_GENERATING_OUTPUT
+template<> class CORRADE_TESTSUITE_EXPORT Comparator<Compare::String> {
+    public:
+        ComparisonStatusFlags operator()(Containers::StringView actual, Containers::StringView expected);
+
+        void printMessage(ComparisonStatusFlags flags, Utility::Debug& out, const char* actual, const char* expected) const;
+
+    private:
+        Containers::StringView _actualValue;
+        Containers::StringView _expectedValue;
+};
+
 template<> class CORRADE_TESTSUITE_EXPORT Comparator<Compare::StringHasPrefix> {
     public:
         ComparisonStatusFlags operator()(Containers::StringView actual, Containers::StringView expectedPrefix);

--- a/src/Corrade/TestSuite/Compare/Test/CMakeLists.txt
+++ b/src/Corrade/TestSuite/Compare/Test/CMakeLists.txt
@@ -40,6 +40,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure.h.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/configure.h)
 
 corrade_add_test(TestSuiteCompareContainerTest ContainerTest.cpp)
+corrade_add_test(TestSuiteCompareDiffTest DiffTest.cpp)
 corrade_add_test(TestSuiteCompareSortedContainerTest SortedContainerTest.cpp)
 corrade_add_test(TestSuiteCompareFileTest FileTest.cpp
     FILES

--- a/src/Corrade/TestSuite/Compare/Test/DiffTest.cpp
+++ b/src/Corrade/TestSuite/Compare/Test/DiffTest.cpp
@@ -1,0 +1,146 @@
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Corrade/TestSuite/Tester.h"
+#include "Corrade/TestSuite/Compare/Container.h"
+#include "Corrade/TestSuite/Compare/Implementation/Diff.h"
+
+namespace Corrade { namespace TestSuite { namespace Compare { namespace Test { namespace {
+
+struct DiffTest: TestSuite::Tester {
+    explicit DiffTest();
+
+    void longestMatchingSlice();
+    void matchingSlicesInto();
+};
+
+DiffTest::DiffTest() {
+    addTests({&DiffTest::longestMatchingSlice,
+              &DiffTest::matchingSlicesInto});
+}
+
+void DiffTest::longestMatchingSlice() {
+    typedef Containers::Triple<std::size_t, std::size_t, size_t> Triple;
+
+    /* Empty inputs */
+    {
+        int a[]{3};
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(nullptr, nullptr),
+            Triple{});
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(a, nullptr),
+            Triple{});
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(nullptr, a),
+            Triple{});
+
+    /* No match */
+    } {
+        int a[]{3, 17, 5};
+        int b[]{26, 4, 13};
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(a, b),
+            Triple{});
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(b, a),
+            Triple{});
+
+    /* Full match */
+    }{
+        int a[]{17, 3, 5, -1776};
+        int b[]{17, 3, 5, -1776};
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(a, b),
+            (Triple{0, 0, 4}));
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(b, a),
+            (Triple{0, 0, 4}));
+
+    /* Prefix match */
+    } {
+        int a[]{17, 3, 5, -1776};
+        int b[]{17, 3, 5};
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(a, b),
+            (Triple{0, 0, 3}));
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(b, a),
+            (Triple{0, 0, 3}));
+
+    /* Suffix match */
+    } {
+        int a[]{17, 3, 5, -1776};
+        int b[]{3, 5, -1776};
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(a, b),
+            (Triple{1, 0, 3}));
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(b, a),
+            (Triple{0, 1, 3}));
+
+    /* Partial match from both */
+    } {
+        int a[]{17, 3, 21, 5, -1776, 24};
+        int b[]{26, 5, -1776, 22};
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(a, b),
+            (Triple{3, 1, 2}));
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(b, a),
+            (Triple{1, 3, 2}));
+
+    /* Multiple matches */
+    } {
+        int a[]{17, 3, 0, 5, -1776, 24, -1776, 8, 26, 5, -1776, 22, 26, 5, 23};
+        int b[]{22, 26, 5, -1776, 22};
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(a, b),
+            (Triple{8, 1, 4}));
+        CORRADE_COMPARE(Implementation::longestMatchingSlice<int>(b, a),
+            (Triple{1, 8, 4}));
+    }
+}
+
+void DiffTest::matchingSlicesInto() {
+    typedef Containers::Triple<std::size_t, std::size_t, size_t> Triple;
+
+    /*      0  1   2  3  4               5   6          7  8  9  10  11 */
+    int a[]{0, 1, 56, 2, 3,             23, 11,         7, 8, 9, 11, 12};
+    int b[]{   1,     2, 3, 4, 5, 7, 8,         10, 12, 7, 8, 9,     12, 23};
+    /*         0      1  2  3  4  5  6           7   8  9 10 11      12 */
+
+    /* With the arguments swapped it should just swap first() and second() */
+    {
+        Containers::Array<Triple> out;
+        Implementation::matchingSlicesInto<int>(out, a, 0, b, 0);
+        CORRADE_COMPARE_AS(out, Containers::arrayView<Triple>({
+            {1, 0, 1},
+            {3, 1, 2},
+            {7, 9, 3},
+            {11, 12, 1}
+        }), TestSuite::Compare::Container);
+    } {
+        Containers::Array<Triple> out;
+        Implementation::matchingSlicesInto<int>(out, b, 0, a, 0);
+        CORRADE_COMPARE_AS(out, Containers::arrayView<Triple>({
+            {0, 1, 1},
+            {1, 3, 2},
+            {9, 7, 3},
+            {12, 11, 1}
+        }), TestSuite::Compare::Container);
+    }
+}
+
+}}}}}
+
+CORRADE_TEST_MAIN(Corrade::TestSuite::Compare::Test::DiffTest)

--- a/src/Corrade/TestSuite/Compare/Test/StringTest.cpp
+++ b/src/Corrade/TestSuite/Compare/Test/StringTest.cpp
@@ -92,6 +92,58 @@ const struct {
         "       +  a l l\n"
         "       +\n"
         "        yes\n"},
+    {"small single-line difference in the middle",
+        "hello world\n"
+        "this is cool\n"
+        "yes",
+        "hello world\n"
+        "this isn't cool\n"
+        "yes",
+        "Strings a and b are different. Actual (+) vs expected (-):\n"
+        "        hello world\n"
+        "       -this isn't cool\n"
+        "       +this is cool\n"
+        "        yes\n",
+        "Strings b and a are different. Actual (+) vs expected (-):\n"
+        "        hello world\n"
+        "       -this is cool\n"
+        "       +this isn't cool\n"
+        "        yes\n"},
+    {"difference in the middle of a UTF-8 character",
+        "média",
+        "mèdia",
+        "Strings a and b are different. Actual (+) vs expected (-):\n"
+        "       -mèdia\n"
+        "       +média\n",
+        "Strings b and a are different. Actual (+) vs expected (-):\n"
+        "       -média\n"
+        "       +mèdia\n"},
+    {"difference next to a UTF-8 character",
+        "média",
+        "mědia",
+        "Strings a and b are different. Actual (+) vs expected (-):\n"
+        "       -mědia\n"
+        "       +média\n",
+        "Strings b and a are different. Actual (+) vs expected (-):\n"
+        "       -média\n"
+        "       +mědia\n"},
+    {"large single-line difference in the middle",
+        "hello world\n"
+        "this is cool\n"
+        "yes",
+        "hello world\n"
+        "That's awful\n"
+        "yes",
+        "Strings a and b are different. Actual (+) vs expected (-):\n"
+        "        hello world\n"
+        "       -That's awful\n"
+        "       +this is cool\n"
+        "        yes\n",
+        "Strings b and a are different. Actual (+) vs expected (-):\n"
+        "        hello world\n"
+        "       -this is cool\n"
+        "       +That's awful\n"
+        "        yes\n"},
     {"different at the start",
         "Hello\n"
         "world!\n"

--- a/src/Corrade/TestSuite/Tester.h
+++ b/src/Corrade/TestSuite/Tester.h
@@ -270,9 +270,9 @@ differ, which becomes useful with large data sizes:
 @snippet TestSuite.cpp Compare-Container
 </li>
 <li>
-@ref Compare::StringHasPrefix, @relativeref{Compare,StringHasSuffix},
+@ref Compare::String provides multi-line diffs; @relativeref{Compare,StringHasPrefix}, @relativeref{Compare,StringHasSuffix},
 @relativeref{Compare,StringContains} and @relativeref{Compare,StringNotContains}
-will provide a better diagnostic compared to e.g. checking
+provide a better diagnostic compared to e.g. checking
 @ref Containers::StringView::hasPrefix() with @ref CORRADE_VERIFY():
 
 @snippet TestSuite.cpp Compare-StringHasPrefix

--- a/src/Corrade/Utility/Debug.cpp
+++ b/src/Corrade/Utility/Debug.cpp
@@ -275,7 +275,7 @@ auto Debug::color(Color color) -> Modifier {
         #undef _c
     }
 
-    return [](Debug&) {}; /* LCOV_EXCL_LINE */
+    CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
 auto Debug::boldColor(Color color) -> Modifier {
@@ -297,7 +297,7 @@ auto Debug::boldColor(Color color) -> Modifier {
         #undef _c
     }
 
-    return [](Debug&) {}; /* LCOV_EXCL_LINE */
+    CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
 }
 
 void Debug::resetColor(Debug& debug) {

--- a/src/Corrade/Utility/Debug.h
+++ b/src/Corrade/Utility/Debug.h
@@ -117,9 +117,10 @@ modifier:
 
 @subsection Utility-Debug-modifiers-colors Colored output
 
-It is possible to color the output using @ref color() and @ref boldColor(). The
-color is automatically reset to previous value on destruction to avoid messing
-up the terminal, you can also use @ref resetColor() to reset it explicitly.
+It is possible to color the output using @ref color(), @ref boldColor() and
+@ref invertedColor(). The color is automatically reset to previous value on
+destruction to avoid messing up the terminal, you can also use
+@ref resetColor() to reset it explicitly.
 
 @snippet Utility.cpp Debug-modifiers-colors
 
@@ -265,7 +266,7 @@ class CORRADE_UTILITY_EXPORT Debug {
         /**
          * @brief Output color
          *
-         * @see @ref color(), @ref boldColor()
+         * @see @ref color(), @ref boldColor(), @ref invertedColor()
          */
         enum class Color: char {
             /**
@@ -394,31 +395,48 @@ class CORRADE_UTILITY_EXPORT Debug {
         /**
          * @brief Set output color
          *
-         * Resets previous @ref color() or @ref boldColor() setting. The color
-         * is also automatically reset on object destruction to a value that
-         * was active in outer scope. If @ref Flag::DisableColors was set, this
-         * function does nothing.
+         * Resets previous @ref color(), @ref boldColor() or
+         * @ref invertedColor() setting. The color is also automatically reset
+         * on object destruction to a value that was active in outer scope. If
+         * @ref Flag::DisableColors was set, this function does nothing.
          */
         static Modifier color(Color color);
 
         /**
          * @brief Set bold output color
          *
-         * Resets previous @ref color() or @ref boldColor() setting. The color
-         * is also automatically reset on object destruction to a value that
-         * was active in outer scope. If @ref Flag::DisableColors was set, this
-         * function does nothing.
+         * Resets previous @ref color(), @ref boldColor() or
+         * @ref invertedColor() setting. The color is also automatically reset
+         * on object destruction to a value that was active in outer scope. If
+         * @ref Flag::DisableColors was set, this function does nothing.
          */
         static Modifier boldColor(Color color);
+
+        #if !defined(CORRADE_TARGET_WINDOWS) || defined(CORRADE_UTILITY_USE_ANSI_COLORS)
+        /**
+         * @brief Set inverted output color
+         * @m_since_latest
+         *
+         * The @p color is used for background while foreground is rendered
+         * with the terminal background color instead. Resets previous
+         * @ref color(), @ref boldColor() or @ref invertedColor() setting. The
+         * color is also automatically reset on object destruction to a value
+         * that was active in outer scope. If @ref Flag::DisableColors was set,
+         * this function does nothing.
+         * @partialsupport Not available on @ref CORRADE_TARGET_WINDOWS "Windows"
+         *      with @ref CORRADE_UTILITY_USE_ANSI_COLORS disabled.
+         */
+        static Modifier invertedColor(Color color);
+        #endif
 
         /**
          * @brief Reset output color
          *
-         * Resets any previous @ref color() or @ref boldColor() setting to a
-         * value that was active in outer scope. The same is also automatically
-         * done on object destruction. If the color was not changed by this
-         * instance or @ref Flag::DisableColors was set, this function does
-         * nothing.
+         * Resets any previous @ref color(), @ref boldColor() or
+         * @ref invertedColor() setting to a value that was active in outer
+         * scope. The same is also automatically done on object destruction. If
+         * the color was not changed by this instance or
+         * @ref Flag::DisableColors was set, this function does nothing.
          */
         static void resetColor(Debug& debug);
 
@@ -763,6 +781,9 @@ class CORRADE_UTILITY_EXPORT Debug {
         #endif
 
         template<Color c, bool bold> CORRADE_UTILITY_LOCAL static Modifier colorInternal();
+        #if !defined(CORRADE_TARGET_WINDOWS) || defined(CORRADE_UTILITY_USE_ANSI_COLORS)
+        template<Color c> CORRADE_UTILITY_LOCAL static Modifier invertedColorInternal();
+        #endif
 
         CORRADE_UTILITY_LOCAL void resetColorInternal();
 
@@ -771,7 +792,7 @@ class CORRADE_UTILITY_EXPORT Debug {
         unsigned short _previousColorAttributes = 0xffff;
         #else
         Color _previousColor;
-        bool _previousColorBold;
+        bool _previousColorBold, _previousColorInverted;
         #endif
         #ifdef CORRADE_SOURCE_LOCATION_BUILTINS_SUPPORTED
         const char* _sourceLocationFile{};

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -977,10 +977,11 @@ void DebugTest::multithreaded() {
 void DebugTest::sourceLocation() {
     std::ostringstream out;
 
+    std::size_t line;
     {
         Debug redirect{&out};
 
-        !Debug{} << "hello";
+        !Debug{} << "hello"; line = __LINE__;
 
         !Debug{} << "and this is from another line";
 
@@ -990,11 +991,11 @@ void DebugTest::sourceLocation() {
     }
 
     #ifdef CORRADE_SOURCE_LOCATION_BUILTINS_SUPPORTED
-    CORRADE_COMPARE(out.str(),
-        __FILE__ ":983: hello\n"
-        __FILE__ ":985: and this is from another line\n"
-        __FILE__ ":987\n"
-        "this no longer\n");
+    CORRADE_COMPARE(out.str(), Utility::formatString(
+        __FILE__ ":{}: hello\n"
+        __FILE__ ":{}: and this is from another line\n"
+        __FILE__ ":{}\n"
+        "this no longer\n", line, line + 2, line + 4));
     #else
     CORRADE_COMPARE(out.str(),
         "hello\n"

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -36,6 +36,7 @@
 #include "Corrade/TestSuite/Tester.h"
 #include "Corrade/Utility/Debug.h"
 #include "Corrade/Utility/DebugStl.h"
+#include "Corrade/Utility/FormatStl.h" /** @todo remove once Debug is stream-free */
 
 #ifndef CORRADE_TARGET_EMSCRIPTEN
 #include <thread>
@@ -532,7 +533,9 @@ void DebugTest::colors() {
     #else
     std::ostringstream out;
     fn(out);
-    CORRADE_COMPARE(out.str(), (std::string{"\033[0;3" + std::string{data.c} + "m" + data.desc + "\033[1;3" + std::string{data.c} + "m bold\033[0m\n"}));
+    CORRADE_COMPARE(out.str(), formatString(
+        "\033[0;3{0}m{1}\033[1;3{0}m bold\033[0m\n",
+        Containers::StringView{&data.c, 1}, data.desc));
     #endif
 }
 
@@ -988,9 +991,9 @@ void DebugTest::sourceLocation() {
 
     #ifdef CORRADE_SOURCE_LOCATION_BUILTINS_SUPPORTED
     CORRADE_COMPARE(out.str(),
-        __FILE__ ":980: hello\n"
-        __FILE__ ":982: and this is from another line\n"
-        __FILE__ ":984\n"
+        __FILE__ ":983: hello\n"
+        __FILE__ ":985: and this is from another line\n"
+        __FILE__ ":987\n"
         "this no longer\n");
     #else
     CORRADE_COMPARE(out.str(),

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -523,7 +523,9 @@ void DebugTest::colors() {
     auto&& data = ColorsData[testCaseInstanceId()];
     setTestCaseDescription(data.desc);
     auto fn = [&data](std::ostream& out) {
-        Debug{&out} << Debug::color(data.color) << data.desc << Debug::boldColor(data.color) << "bold";
+        Debug{&out}
+            << Debug::color(data.color) << data.desc
+            << Debug::boldColor(data.color) << "bold";
     };
 
     fn(std::cout);
@@ -543,6 +545,7 @@ void DebugTest::colorsAutoReset() {
     /* Auto-reset at the end */
     auto fn = [](std::ostream& out) {
         Debug{&out} << "Default" << Debug::color(Debug::Color::Green) << "Green";
+        Debug{&out} << "Default" << Debug::boldColor(Debug::Color::Green) << "Bold green";
     };
 
     /* Print it for visual verification */
@@ -553,14 +556,20 @@ void DebugTest::colorsAutoReset() {
     #else
     std::ostringstream out;
     fn(out);
-    CORRADE_COMPARE(out.str(), "Default\033[0;32m Green\033[0m\n");
+    CORRADE_COMPARE(out.str(),
+        "Default\033[0;32m Green\033[0m\n"
+        "Default\033[1;32m Bold green\033[0m\n");
     #endif
 }
 
 void DebugTest::colorsExplicitReset() {
     /* Don't reset twice */
     auto fn = [](std::ostream& out) {
-        Debug{&out} << Debug::color(Debug::Color::Red) << "Red"
+        Debug{&out}
+            << Debug::color(Debug::Color::Red) << "Red"
+            << Debug::resetColor << "Default";
+        Debug{&out}
+            << Debug::boldColor(Debug::Color::Red) << "Bold red"
             << Debug::resetColor << "Default";
     };
 
@@ -572,7 +581,9 @@ void DebugTest::colorsExplicitReset() {
     #else
     std::ostringstream out;
     fn(out);
-    CORRADE_COMPARE(out.str(), "\033[0;31mRed\033[0m Default\n");
+    CORRADE_COMPARE(out.str(),
+        "\033[0;31mRed\033[0m Default\n"
+        "\033[1;31mBold red\033[0m Default\n");
     #endif
 }
 
@@ -582,6 +593,7 @@ void DebugTest::colorsDisabled() {
         Debug{&out, Debug::Flag::DisableColors}
             << Debug::color(Debug::Color::Default) << "Default"
             << Debug::color(Debug::Color::Cyan) << "Default"
+            << Debug::boldColor(Debug::Color::Red) << "Default"
             << Debug::resetColor;
     };
 
@@ -593,7 +605,7 @@ void DebugTest::colorsDisabled() {
     #else
     std::ostringstream out;
     fn(out);
-    CORRADE_COMPARE(out.str(), "Default Default\n");
+    CORRADE_COMPARE(out.str(), "Default Default Default\n");
     #endif
 }
 
@@ -603,6 +615,11 @@ void DebugTest::colorsNoOutput() {
         out << Debug::color(Debug::Color::Red);
 
         Debug{&std::cout} << "This shouldn't be red.";
+    } {
+        Debug out{nullptr, Debug::Flag::DisableColors};
+        out << Debug::boldColor(Debug::Color::Red);
+
+        Debug{&std::cout} << "This shouldn't be bold red.";
     }
 
     CORRADE_SKIP("Only possible to test visually.");


### PR DESCRIPTION
TODO: 

- [x] everything
- [x] ~~convert TestSuite::Tester test to it (maybe more? configuration tests?)~~ no, make that opt-in
- [x] diff also the inside line itself, for now only if it's a single deletion and addition
  - [x] implement `Debug::inverseColor()` to show this nicely
  - [x] ~~handle UTF-8 properly~~ skip if it would break UTF-8 characters, for now
- [x] ~~convert `TestSuite::FileToString` etc to use it~~ later

![image](https://user-images.githubusercontent.com/344828/220218029-8254cb07-8b90-408f-8a76-4aac683f3c19.png)

Simple diff algorithm is at http://pynash.org/2013/02/26/diff-in-50-lines/ .