### PR TITLE
Filesystem abstraction library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,8 +201,9 @@ elseif(WIN32)
     endif()
 endif()
 
+option(CORRADE_WITH_FILESYSTEM "Build Filesystem library" ON)
 option(CORRADE_WITH_INTERCONNECT "Build Interconnect library" ON)
-option(CORRADE_WITH_PLUGINMANAGER "Build PluginManager library" ON)
+cmake_dependent_option(CORRADE_WITH_PLUGINMANAGER "Build PluginManager library" ON "NOT CORRADE_WITH_FILESYSTEM" ON)
 option(CORRADE_WITH_TESTSUITE "Build TestSuite library" ON)
 cmake_dependent_option(CORRADE_WITH_UTILITY "Build Utility library" ON "NOT CORRADE_WITH_INTERCONNECT;NOT CORRADE_WITH_PLUGINMANAGER;NOT CORRADE_WITH_TESTSUITE" ON)
 # If we're crosscompiling and the native executable is found, we can skip
@@ -545,6 +546,11 @@ set(CORRADE_PLUGINS_DEBUG_LIBRARY_INSTALL_DIR ${CORRADE_LIBRARY_INSTALL_DIR}/cor
 set(CORRADE_PLUGINS_RELEASE_BINARY_INSTALL_DIR ${CORRADE_BINARY_INSTALL_DIR}/corrade)
 set(CORRADE_PLUGINS_RELEASE_LIBRARY_INSTALL_DIR ${CORRADE_LIBRARY_INSTALL_DIR}/corrade)
 
+set(CORRADE_PLUGINS_FILESYSTEM_DEBUG_BINARY_INSTALL_DIR ${CORRADE_PLUGINS_DEBUG_BINARY_INSTALL_DIR}/filesystems)
+set(CORRADE_PLUGINS_FILESYSTEM_DEBUG_LIBRARY_INSTALL_DIR ${CORRADE_PLUGINS_DEBUG_LIBRARY_INSTALL_DIR}/filesystems)
+set(CORRADE_PLUGINS_FILESYSTEM_RELEASE_BINARY_INSTALL_DIR ${CORRADE_PLUGINS_RELEASE_BINARY_INSTALL_DIR}/filesystems)
+set(CORRADE_PLUGINS_FILESYSTEM_RELEASE_LIBRARY_INSTALL_DIR ${CORRADE_PLUGINS_RELEASE_LIBRARY_INSTALL_DIR}/filesystems)
+
 # Make these paths configurable from outside. This is *not* PATH, because CMake
 # always converts the path to an absolute location internally, making it
 # impossible to specify relative paths there. Sorry in advance for not having
@@ -555,6 +561,18 @@ set(CORRADE_PLUGINS_RELEASE_DIR ""
     CACHE STRING "Base directory where to look for Corrade plugins for release builds")
 set(CORRADE_PLUGINS_DIR ""
     CACHE STRING "Base directory where to look for Corrade plugins")
+
+# Plugin directories. Set only if the above are non-empty. otherwise empty as
+# well.
+if(CORRADE_PLUGINS_DIR)
+    set(CORRADE_PLUGINS_FILESYSTEM_DIR ${CORRADE_PLUGINS_DIR}/filesystems)
+endif()
+if(CORRADE_PLUGINS_DEBUG_DIR)
+    set(CORRADE_PLUGINS_FILESYSTEM_DEBUG_DIR ${CORRADE_PLUGINS_DEBUG_DIR}/filesystems)
+endif()
+if(CORRADE_PLUGINS_RELEASE_DIR)
+    set(CORRADE_PLUGINS_FILESYSTEM_RELEASE_DIR ${CORRADE_PLUGINS_RELEASE_DIR}/filesystems)
+endif()
 
 # Library version. CORRADE_VERSION_YEAR/MONTH is used in
 # src/Corrade/CMakeLists.txt to generate the version.h header.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,23 @@ if(CORRADE_BUILD_DEPRECATED AND CORRADE_INCLUDE_INSTALL_PREFIX AND NOT CORRADE_I
     set(CORRADE_INCLUDE_INSTALL_DIR ${CORRADE_INCLUDE_INSTALL_PREFIX}/${CORRADE_INCLUDE_INSTALL_DIR})
 endif()
 
+# Separate install dirs for debug and release plugins
+set(CORRADE_PLUGINS_DEBUG_BINARY_INSTALL_DIR ${CORRADE_BINARY_INSTALL_DIR}/corrade-d)
+set(CORRADE_PLUGINS_DEBUG_LIBRARY_INSTALL_DIR ${CORRADE_LIBRARY_INSTALL_DIR}/corrade-d)
+set(CORRADE_PLUGINS_RELEASE_BINARY_INSTALL_DIR ${CORRADE_BINARY_INSTALL_DIR}/corrade)
+set(CORRADE_PLUGINS_RELEASE_LIBRARY_INSTALL_DIR ${CORRADE_LIBRARY_INSTALL_DIR}/corrade)
+
+# Make these paths configurable from outside. This is *not* PATH, because CMake
+# always converts the path to an absolute location internally, making it
+# impossible to specify relative paths there. Sorry in advance for not having
+# the dir selection button in CMake GUI.
+set(CORRADE_PLUGINS_DEBUG_DIR ""
+    CACHE STRING "Base directory where to look for Corrade plugins for debug builds")
+set(CORRADE_PLUGINS_RELEASE_DIR ""
+    CACHE STRING "Base directory where to look for Corrade plugins for release builds")
+set(CORRADE_PLUGINS_DIR ""
+    CACHE STRING "Base directory where to look for Corrade plugins")
+
 # Library version. CORRADE_VERSION_YEAR/MONTH is used in
 # src/Corrade/CMakeLists.txt to generate the version.h header.
 set(CORRADE_LIBRARY_VERSION 2.4)

--- a/doc/building-corrade.dox
+++ b/doc/building-corrade.dox
@@ -674,6 +674,16 @@ compatibility if `CORRADE_BUILD_DEPRECATED` isn't disabled.
     with the unified sysroot layout. Defaults to ``.``. If a relative path is
     used, it's relative to `CMAKE_INSTALL_PREFIX`.
 
+Various plugin interfaces search for plugins in locations and order documented
+in @ref PluginManager::implicitPluginSearchPaths() and equivalent functions in
+plugin interfaces. In most cases the implicit behavior does the right
+thing, but if you need to override those, use the `CORRADE_PLUGINS_DIR`,
+`CORRADE_PLUGINS_DEBUG_DIR` and `CORRADE_PLUGINS_RELEASE_DIR` CMake variables.
+Those are empty by default, which means no hardcoded path is used. Another
+option is supplying the plugin search path to the @ref PluginManager::Manager
+constructor either using the same CMake variables (passed through to
+preprocessor, see @ref corrade-cmake) or via any other means.
+
 @subsection building-corrade-tests Building and running tests
 
 Building of tests is controlled by the following options:

--- a/doc/building-corrade.dox
+++ b/doc/building-corrade.dox
@@ -531,6 +531,8 @@ By default the library is built with everything included. Using the following
 `CORRADE_WITH_*` CMake options you can specify which parts will be built and
 which not:
 
+-   `CORRADE_WITH_FILESYSTEM` --- Build the @ref Filesystem library. Enables
+    also building of the PluginManager library.
 -   `CORRADE_WITH_INTERCONNECT` --- Build the @ref Interconnect library.
     Enables also building of the Utility library.
 -   `CORRADE_WITH_MAIN` --- build The @ref main "Main" library. Enabled

--- a/doc/corrade-cmake.dox
+++ b/doc/corrade-cmake.dox
@@ -127,6 +127,14 @@ following:
 -   `Corrade_FOUND` --- Whether the base library was found
 -   `CORRADE_LIB_SUFFIX_MODULE` --- Path to `CorradeLibSuffix.cmake` module,
     which tries to autodetect the `LIB_SUFFIX` variable
+-   `CORRADE_PLUGINS_DEBUG_DIR` --- Base directory with dynamic plugins for
+    debug builds, defaults to `corrade-d/` subdirectory of dir where Corrade libraries were found
+-   `CORRADE_PLUGINS_RELEASE_DIR` --- Base directory with dynamic plugins for
+    release builds, defaults to `corrade/` subdirectory of dir where Corrade
+    libraries were found
+-   `CORRADE_PLUGINS_DIR` --- Base directory with dynamic plugins, defaults to
+    `CORRADE_PLUGINS_RELEASE_DIR` in release builds and multi-configuration
+    builds or to `CORRADE_PLUGINS_DEBUG_DIR` in debug builds
 
 This command will try to find only the base library, not the optional
 components, which are:

--- a/doc/corrade-cmake.dox
+++ b/doc/corrade-cmake.dox
@@ -140,6 +140,7 @@ This command will try to find only the base library, not the optional
 components, which are:
 
 -   `Containers` --- @ref Containers library
+-   `Filesystem` --- @ref Filesystem library
 -   `Interconnect` --- @ref Interconnect library
 -   `Main` --- @ref main "Main" library
 -   `PluginManager` --- @ref PluginManager library

--- a/doc/corrade-cmake.dox
+++ b/doc/corrade-cmake.dox
@@ -126,10 +126,7 @@ following:
 
 -   `Corrade_FOUND` --- Whether the base library was found
 -   `CORRADE_LIB_SUFFIX_MODULE` --- Path to `CorradeLibSuffix.cmake` module,
-    which tries to autodetect value of `LIB_SUFFIX` variable
--   `CORRADE_INCLUDE_INSTALL_PREFIX` --- Prefix where to put
-    platform-independent include and other files, defaults to `.`. If a
-    relative path is used, it's relative to `CMAKE_INSTALL_PREFIX`.
+    which tries to autodetect the `LIB_SUFFIX` variable
 
 This command will try to find only the base library, not the optional
 components, which are:

--- a/modules/FindCorrade.cmake
+++ b/modules/FindCorrade.cmake
@@ -9,8 +9,18 @@
 # This module tries to find the base Corrade library and then defines the
 # following:
 #
-#  Corrade_FOUND                  - Whether the base library was found
-#  CORRADE_LIB_SUFFIX_MODULE      - Path to CorradeLibSuffix.cmake module
+#  Corrade_FOUND                - Whether the base library was found
+#  CORRADE_LIB_SUFFIX_MODULE    - Path to CorradeLibSuffix.cmake module
+#  CORRADE_PLUGINS_DEBUG_DIR    - Base directory with dynamic plugins for
+#   debug builds, defaults to corrade-d/ subdirectory of dir where Corrade
+#   libraries were found
+#  CORRADE_PLUGINS_RELEASE_DIR  - Base directory with dynamic plugins for
+#   release builds, defaults to corrade/ subdirectory of dir where Corrade
+#   libraries were found
+#  CORRADE_PLUGINS_DIR          - Base directory with dynamic plugins,
+#   defaults to :variable:`CORRADE_PLUGINS_RELEASE_DIR` in release builds and
+#   multi-configuration builds or to :variable:`CORRADE_PLUGINS_DEBUG_DIR` in
+#   debug builds
 #
 # This command will try to find only the base library, not the optional
 # components, which are:
@@ -137,6 +147,14 @@
 #   C++11, 14, 17 or 20 in cases where it's not possible to use
 #   :prop_tgt:`CORRADE_CXX_STANDARD`. Not defined if a standard switch is
 #   already present in :variable:`CMAKE_CXX_FLAGS`.
+#  CORRADE_BINARY_INSTALL_DIR   - Binary installation directory
+#  CORRADE_LIBRARY_INSTALL_DIR  - Library installation directory
+#  CORRADE_PLUGINS_[DEBUG|RELEASE]_BINARY_INSTALL_DIR - Plugin binary
+#   installation directory
+#  CORRADE_PLUGINS_[DEBUG|RELEASE]_LIBRARY_INSTALL_DIR - Plugin library
+#   installation directory
+#  CORRADE_INCLUDE_INSTALL_DIR  - Header installation directory
+#  CORRADE_PLUGINS_INCLUDE_INSTALL_DIR - Plugin header installation directory
 #
 # Corrade provides these macros and functions:
 #
@@ -736,6 +754,7 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.16)
     set(_CORRADE_REASON_FAILURE_MESSAGE REASON_FAILURE_MESSAGE "${_CORRADE_REASON_FAILURE_MESSAGE}")
 endif()
 
+# Complete the check with also all components
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Corrade REQUIRED_VARS
     CORRADE_INCLUDE_DIR
@@ -744,11 +763,18 @@ find_package_handle_standard_args(Corrade REQUIRED_VARS
     HANDLE_COMPONENTS
     ${_CORRADE_REASON_FAILURE_MESSAGE})
 
-# Finalize the finding process
 include(${CORRADE_USE_MODULE})
 
+# Installation dirs
+include(${CORRADE_LIB_SUFFIX_MODULE})
+set(CORRADE_BINARY_INSTALL_DIR bin)
+set(CORRADE_LIBRARY_INSTALL_DIR lib${LIB_SUFFIX})
 set(CORRADE_INCLUDE_INSTALL_DIR include/Corrade)
-
+set(CORRADE_PLUGINS_INCLUDE_INSTALL_DIR include/CorradePlugins)
+set(CORRADE_PLUGINS_DEBUG_BINARY_INSTALL_DIR ${CORRADE_BINARY_INSTALL_DIR}/corrade-d)
+set(CORRADE_PLUGINS_DEBUG_LIBRARY_INSTALL_DIR ${CORRADE_LIBRARY_INSTALL_DIR}/corrade-d)
+set(CORRADE_PLUGINS_RELEASE_BINARY_INSTALL_DIR ${CORRADE_BINARY_INSTALL_DIR}/corrade)
+set(CORRADE_PLUGINS_RELEASE_LIBRARY_INSTALL_DIR ${CORRADE_LIBRARY_INSTALL_DIR}/corrade)
 if(CORRADE_BUILD_DEPRECATED AND CORRADE_INCLUDE_INSTALL_PREFIX AND NOT CORRADE_INCLUDE_INSTALL_PREFIX STREQUAL ".")
     message(DEPRECATION "CORRADE_INCLUDE_INSTALL_PREFIX is obsolete as its primary use was for old Android NDK versions. Please switch to the NDK r19+ layout instead of using this variable and recreate your build directory to get rid of this warning.")
     set(CORRADE_INCLUDE_INSTALL_DIR ${CORRADE_INCLUDE_INSTALL_PREFIX}/${CORRADE_INCLUDE_INSTALL_DIR})

--- a/modules/FindCorrade.cmake
+++ b/modules/FindCorrade.cmake
@@ -26,6 +26,7 @@
 # components, which are:
 #
 #  Containers                   - Containers library
+#  Filesystem                   - Filesystem library
 #  Interconnect                 - Interconnect library
 #  Main                         - Main library
 #  PluginManager                - PluginManager library
@@ -153,6 +154,10 @@
 #   installation directory
 #  CORRADE_PLUGINS_[DEBUG|RELEASE]_LIBRARY_INSTALL_DIR - Plugin library
 #   installation directory
+#  CORRADE_PLUGINS_FILESYSTEM_[DEBUG|RELEASE]_BINARY_INSTALL_DIR - Filesystem
+#   plugin binary installation directory
+#  CORRADE_PLUGINS_FILESYSTEM_[DEBUG|RELEASE]_LIBRARY_INSTALL_DIR - Filesystem
+#   plugin library installation directory
 #  CORRADE_INCLUDE_INSTALL_DIR  - Header installation directory
 #  CORRADE_PLUGINS_INCLUDE_INSTALL_DIR - Plugin header installation directory
 #
@@ -391,7 +396,7 @@ set(CORRADE_LIB_SUFFIX_MODULE ${_CORRADE_MODULE_DIR}/CorradeLibSuffix.cmake)
 # Component distinction (listing them explicitly to avoid mistakes with finding
 # unknown components)
 set(_CORRADE_LIBRARY_COMPONENTS
-    Containers Interconnect Main PluginManager TestSuite Utility)
+    Containers Filesystem Interconnect Main PluginManager TestSuite Utility)
 # These libraries are excluded from DLL detection if Corrade is built as shared
 set(_CORRADE_LIBRARY_COMPONENTS_ALWAYS_STATIC
     Main)
@@ -404,10 +409,11 @@ set(_CORRADE_EXECUTABLE_COMPONENTS rc)
 # Currently everything is enabled implicitly. Keep in sync with Corrade's root
 # CMakeLists.txt.
 set(_CORRADE_IMPLICITLY_ENABLED_COMPONENTS
-    Containers Interconnect Main PluginManager TestSuite Utility rc)
+    Containers Filesystem Interconnect Main PluginManager TestSuite Utility rc)
 
 # Inter-component dependencies
 set(_CORRADE_Containers_DEPENDENCIES Utility)
+set(_CORRADE_Filesystem_DEPENDENCIES PluginManager)
 set(_CORRADE_Interconnect_DEPENDENCIES Containers Utility)
 set(_CORRADE_PluginManager_DEPENDENCIES Containers Utility rc)
 set(_CORRADE_TestSuite_DEPENDENCIES Containers Utility Main) # see below
@@ -600,6 +606,7 @@ foreach(_component ${Corrade_FIND_COMPONENTS})
         endif()
 
         # No special setup for Containers library
+        # No special setup for Filesystem library
 
         # Interconnect library
         if(_component STREQUAL Interconnect)
@@ -779,3 +786,8 @@ if(CORRADE_BUILD_DEPRECATED AND CORRADE_INCLUDE_INSTALL_PREFIX AND NOT CORRADE_I
     message(DEPRECATION "CORRADE_INCLUDE_INSTALL_PREFIX is obsolete as its primary use was for old Android NDK versions. Please switch to the NDK r19+ layout instead of using this variable and recreate your build directory to get rid of this warning.")
     set(CORRADE_INCLUDE_INSTALL_DIR ${CORRADE_INCLUDE_INSTALL_PREFIX}/${CORRADE_INCLUDE_INSTALL_DIR})
 endif()
+
+set(CORRADE_PLUGINS_FILESYSTEM_DEBUG_BINARY_INSTALL_DIR ${CORRADE_PLUGINS_DEBUG_BINARY_INSTALL_DIR}/filesystems)
+set(CORRADE_PLUGINS_FILESYSTEM_DEBUG_LIBRARY_INSTALL_DIR ${CORRADE_PLUGINS_DEBUG_LIBRARY_INSTALL_DIR}/filesystems)
+set(CORRADE_PLUGINS_FILESYSTEM_RELEASE_BINARY_INSTALL_DIR ${CORRADE_PLUGINS_RELEASE_BINARY_INSTALL_DIR}/filesystems)
+set(CORRADE_PLUGINS_FILESYSTEM_RELEASE_LIBRARY_INSTALL_DIR ${CORRADE_PLUGINS_RELEASE_LIBRARY_INSTALL_DIR}/filesystems)

--- a/src/Corrade/CMakeLists.txt
+++ b/src/Corrade/CMakeLists.txt
@@ -96,6 +96,10 @@ if(CORRADE_WITH_UTILITY) # Cyclic dependency of Containers and Utility
     add_subdirectory(Containers)
 endif()
 
+if(CORRADE_WITH_FILESYSTEM)
+    add_subdirectory(Filesystem)
+endif()
+
 if(CORRADE_WITH_INTERCONNECT)
     add_subdirectory(Interconnect)
 endif()

--- a/src/Corrade/Filesystem/AbstractFilesystem.cpp
+++ b/src/Corrade/Filesystem/AbstractFilesystem.cpp
@@ -1,0 +1,33 @@
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "AbstractFilesystem.h"
+
+namespace Corrade { namespace Filesystem {
+
+
+
+}}

--- a/src/Corrade/Filesystem/AbstractFilesystem.h
+++ b/src/Corrade/Filesystem/AbstractFilesystem.h
@@ -1,0 +1,549 @@
+#ifndef Corrade_Filesystem_AbstractFilesystem_h
+#define Corrade_Filesystem_AbstractFilesystem_h
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Class @ref Corrade::Filesystem::AbstractFilesystem
+ * @m_since_latest
+ */
+
+#include <cstdint>
+
+#include "Corrade/Filesystem/visibility.h"
+#include "Corrade/PluginManager/AbstractPlugin.h"
+
+// TODO argh! there's CORRADE_WITH_FILESYSTEM, and then corrade-filesystem should be named how? or corrade-fs? that's eh ... but maybe..., corrade-rc is a precedent already
+// TODO and same would happen with this named Fs and corrade-fs...
+namespace Corrade { namespace Filesystem {
+
+/**
+@brief Filesystem feature
+@m_since_latest
+
+@see @ref FilesystemFeatures, @ref AbstractFilesystem::features()
+*/
+enum class FilesystemFeature: std::uint8_t {
+    // TODO finish docs for all
+
+    // TODO distinguish reading and writing already? should probably name the features as such already
+    OpenPath = 1 << 0,
+    OpenData = 1 << 1,
+
+    // TODO multiple files, not just e.g. a single compression stream
+    Files = 1 << 2,
+
+    // TODO has a notion of directories (e.g. Utility::Resource doesn't have)
+    Directories = Files|(1 << 3),
+
+    // TODO can use setCurrentDirectory()
+    WorkingDirectory = Directories|(1 << 4),
+
+    // TODO can use mapRead()
+    Map = Files|(1 << 5)
+};
+
+/**
+@brief Filesystem features
+@m_since_latest
+
+@see @ref AbstractFilesystem::features()
+*/
+typedef Containers::EnumSet<FilesystemFeature> FilesystemFeatures;
+
+CORRADE_ENUMSET_OPERATORS(FilesystemFeatures)
+
+/**
+@debugoperatorenum{FilesystemFeature}
+@m_since_latest
+*/
+CORRADE_FILESYSTEM_EXPORT Utility::Debug& operator<<(Utility::Debug& debug, FilesystemFeature value);
+
+/**
+@debugoperatorenum{FilesystemFeatures}
+@m_since_latest
+*/
+CORRADE_FILESYSTEM_EXPORT Utility::Debug& operator<<(Utility::Debug& debug, FilesystemFeatures value);
+
+/**
+@brief Filesystem listing flag
+@m_since_latest
+
+@see @ref FilesystemListFlags, @ref AbstractFilesystem::list()
+*/
+enum class FilesystemListFlag: std::uint8_t {
+    /**
+     * Skip regular files
+     */
+    SkipFiles = 1 << 0,
+
+    /** Skip directories */
+    SkipDirectories = 1 << 1
+};
+
+/**
+@brief Filesystem listing flags
+@m_since_latest
+
+@see @ref AbstractFilesystem::list()
+*/
+typedef Containers::EnumSet<FilesystemListFlag> FilesystemListFlags;
+
+CORRADE_ENUMSET_OPERATORS(FilesystemListFlags)
+
+/**
+@debugoperatorenum{FilesystemListFlag}
+@m_since_latest
+*/
+CORRADE_FILESYSTEM_EXPORT Utility::Debug& operator<<(Utility::Debug& debug, FilesystemListFlag value);
+
+/**
+@debugoperatorenum{FilesystemListFlags}
+@m_since_latest
+*/
+CORRADE_FILESYSTEM_EXPORT Utility::Debug& operator<<(Utility::Debug& debug, FilesystemListFlags value);
+
+/**
+@brief Base for filesystem plugins
+@m_since_latest
+
+TODO mention why it covers both compression streams alone and filesystems (to handle tar.zst and such nicely)
+
+@section Filesystem-AbstractFilesystem-usage Usage
+
+Filesystems are implemented as plugins. For example, reading an image from a
+ZIP filesystem using the @ref AnyFilesystem plugin could be done like this:
+
+@snippet Filesystem.cpp AbstractFilesystem-usage
+
+See `*Filesystem` classes in the @ref Fs namespace for available filesystem
+plugins.
+
+TODO expand similarly to other plugins
+
+@subsection Filesystem-AbstractFilesystem-usage-zero-copy Zero-copy file loading
+
+Some filesystems have a possibility to map files into virtual memory instead of
+reading them fully into the physical memory, which can save unnecessary copying
+of data. Files can be read using @ref mapRead(), which then returns a virtual
+memory range that's kept alive at least until either the array deleter is
+called or the filesystem is closed --- check particular plugin documentation
+for details.
+
+File-based filesystems (such as ZIP files) can be
+*/
+class CORRADE_FILESYSTEM_EXPORT AbstractFilesystem: public PluginManager::AbstractPlugin {
+    public:
+        /**
+         * @brief Deleter for arrays returned from @ref mapRead()
+         *
+         * To be used internally by the plugin implementation.
+         */
+        struct MapDeleter {
+            /** @brief Implementation-specific data pointer */
+            void* userData;
+
+            /** @brief Implementation-specific deleter implementation */
+            void(*deleter)(void*, char*, std::size_t);
+
+            /**
+             * @brief Deleter
+             *
+             * Calls @ref deleter with @ref userData, @p data and @p size.
+             */
+            void operator()(char* data, std::size_t size) const {
+                deleter(userData, data, size);
+            }
+        };
+
+        /**
+         * @brief Plugin interface
+         *
+         * @snippet Corrade/Filesystem/AbstractFilesystem.h interface
+         *
+         * @see @ref CORRADE_FILESYSTEM_ABSTRACTFILESYSTEM_PLUGIN_INTERFACE
+         */
+        static Containers::StringView pluginInterface();
+
+        #ifndef CORRADE_PLUGINMANAGER_NO_DYNAMIC_PLUGIN_SUPPORT
+        /**
+         * @brief Plugin search paths
+         *
+         * Looks into `magnum/importers/` or `magnum-d/importers/` next to the
+         * dynamic @ref Filesystem library, next to the executable and
+         * elsewhere according to the rules documented in
+         * @ref PluginManager::implicitPluginSearchPaths(). The search
+         * directory can be also hardcoded using the `CORRADE_PLUGINS_DIR`
+         * CMake variables, see @ref building for more information.
+         *
+         * Not defined on platforms without
+         * @ref CORRADE_PLUGINMANAGER_NO_DYNAMIC_PLUGIN_SUPPORT "dynamic plugin support".
+         */
+        static Containers::Array<Containers::String> pluginSearchPaths();
+        #endif
+
+        /** @brief Default constructor */
+        explicit AbstractFilesystem();
+
+        /** @brief Constructor with access to plugin manager */
+        explicit AbstractFilesystem(PluginManager::Manager<AbstractFilesystem>& manager);
+
+        /** @brief Plugin manager constructor */
+        /* The plugin name is passed as a const& to make it possible for people
+           to implement plugins without even having to include the StringView
+           header. */
+        explicit AbstractFilesystem(PluginManager::AbstractManager& manager, const Containers::StringView& plugin);
+
+        /** @brief Features supported by this filesystem */
+        FilesystemFeatures features() const { return doFeatures(); }
+
+        // TODO some builtin way to recognize path schemes such as file://? or is that a job for AnyFilesystem?
+
+        /**
+         * @brief Whether any filesystem is opened
+         *
+         * Returns @cpp true @ce if a file is opened with @ref openPath(),
+         * @ref openData() or @ref openMemory() and @ref close() wasn't called
+         * yet; @cpp false @ce otherwise.
+         */
+        bool isOpened() const;
+
+        /**
+         * @brief Open path as a filesystem
+         *
+         * Closes previous filesystem, if it was opened, and tries to open
+         * given path. Available only if @ref FilesystemFeature::OpenPath is
+         * supported. On failure prints a message to @ref Utility::Error and
+         * returns @cpp false @ce.
+         */
+        // TODO distinguish read and modification? likely a separate api?
+        bool openPath(Containers::StringView path);
+        // TODO mention that the path can be interpreted as just anything, for example a name of a compiled-in resource, or a URL ...
+
+        // TODO damn that means i cannot just simply load the data with Path as a fallback, right? siigh
+        // TODO fuh no, just have an option to compile all that Path compat out
+        // TODO because then it might make sense to open a zip file from FS on desktop but (maybe) not on Emscripten, and that has to be some compile-time switch
+
+        /**
+         * @brief Open data as a filesystem
+         *
+         * Closes previous filesystem, if it was opened, and tries to open
+         * given raw data. Available only if @ref FilesystemFeature::OpenData
+         * is supported. On failure prints a message to @ref Utility::Error and
+         * returns @cpp false @ce.
+         *
+         * The @p data is not expected to be alive after the function exits.
+         * Using @ref openMemory() instead as can avoid unnecessary copies in
+         * exchange for stricter requirements on @p data lifetime.
+         * @see @ref features(), @ref openPath()
+         */
+        // TODO distinguish read and modification? likely a separate api?
+        bool openData(Containers::ArrayView<const void> data);
+
+        /**
+         * @brief Open memory as a filesystem
+         *
+         * Closes previous filesystem, if it was opened, and tries to open
+         * given memory. Available only if @ref FilesystemFeature::OpenData
+         * is supported. On failure prints a message to @ref Utility::Error and
+         * returns @cpp false @ce.
+         *
+         * Unlike @ref openData(), this function expects @p memory to stay in
+         * scope until the importer is destructed, @ref close() is called or
+         * another file is opened. This allows the implementation to directly
+         * operate on the provided memory, without having to allocate a local
+         * copy to extend its lifetime.
+         * @see @ref features(), @ref openPath()
+         */
+        bool openMemory(Containers::ArrayView<const void> data);
+
+        /**
+         * @brief Close the filesystem
+         *
+         * On some implementations an explicit call to this function may result
+         * in freed memory and/or system resources. This call is also done
+         * automatically when the importer gets destructed or when another
+         * filesystem is opened.
+         *
+         * Note that files opened through @ref mapRead() might not be available
+         * anymore once this function is called --- see documentation of the
+         * particular plugin for more information.
+         */
+        // TODO variant of close that returns the modified data
+        void close();
+
+        /** @{ @name Metadata access */
+
+        /**
+         * @brief Current directory
+         *
+         * Available only if @ref FilesystemFeature::Directories is supported.
+         * If @ref FilesystemFeature::CurrentDirectory is not supported, always
+         * returns an empty string. Relative paths passed to @ref list(),
+         * @ref exists(), @ref read(), @ref mapRead() as well as
+         * @ref setCurrentDirectory() are taken relative to this path. Expects
+         * that a filesystem is opened.
+         * @see @ref setCurrentDirectory()
+         */
+        Containers::String currentDirectory();
+
+        /**
+         * @brief Change current directory
+         *
+         * Available only if @ref FilesystemFeature::CurrentDirectory is
+         * supported. By default the current directory is an empty string,
+         * which is equivalent to root of the filesytem opened with
+         * @ref openFile(), @ref openData() or @ref openMemory(). Non-absolute
+         * paths passed to @ref list(), @ref exists(),
+         * @ref read(Containers::StringView),
+         * @ref mapRead(Containers::StringView) as well as to this function
+         * itself are taken relative to the current directory.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @cpp false @ce. Expects that a filesystem is opened.
+         */
+        bool setCurrentDirectory(Containers::StringView path);
+
+        /**
+         * @brief Check if given file or directory exists
+         *
+         * Available only if @ref FilesystemFeature::Files is supported.
+         *
+         * Unlike other APIs such as @ref read() or @ref list(), and
+         * consistently with @ref Utility::Path::exists(), this function
+         * doesn't have any failure state nor it produces any error message ---
+         * and if it returns @cpp true @ce, it doesn't necessarily mean the
+         * file can be opened or the directory listed, that's only possible to
+         * know once such operation is attempted.
+         * @see @ref isDirectory()
+         */
+        bool exists(Containers::StringView file);
+
+        /**
+         * @brief Check if given file or directory exists
+         *
+         * Available only if @ref FilesystemFeature::Directories is supported.
+         *
+         * Unlike other APIs such as @ref list(), and consistently with
+         * @ref Utility::Path::isDirectory(), this function doesn't have any
+         * failure state nor it produces any error message --- and if it
+         * returns @cpp true @ce, it doesn't necessarily mean the file can be
+         * opened or the directory listed, that's only possible to know once
+         * such operation is attempted.
+         * @see @ref isDirectory()
+         */
+        bool isDirectory(Containers::StringView file);
+
+        /**
+         * @brief List files in a directory
+         *
+         * Available only if @ref FilesystemFeature::Directories is supported.
+         * Non-absolute @p path is interpreted relative to
+         * @ref currentDirectory(), If @p path is empty, lists
+         * @ref currentDirectory() itself. Returns always just the filenames,
+         * doesn't recurse into subdirectories. Use
+         * @ref list(FilesystemListFlags) on filesystems that support only
+         * @ref FilesystemFeature::Files.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @ref Containers::NullOpt. Expects that a filesystem is opened.
+         */
+        Containers::Optional<Containers::Array<Containers::String>> list(Containers::StringView path, FilesystemListFlags flags = {});
+
+        /**
+         * @brief List files in current or root directory
+         *
+         * Available only if @ref FilesystemFeature::Files is supported. If
+         * @ref FilesystemFeature::Directories is supported as well, lists
+         * files in @ref currentDirectory(), otherwise lists all files in the
+         * filesystem.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @ref Containers::NullOpt. Expects that a filesystem is opened.
+         */
+        Containers::Optional<Containers::Array<Containers::String>> list(FilesystemListFlags flags = {});
+
+        /**
+         * @brief Size of the whole filesystem contents
+         * @m_since_latest
+         *
+         * Available only if @ref FilesystemFeature::Files is *not* supported,
+         * i.e. the filesystem is for example just a compressed data stream.
+         * Use @ref size(Containers::StringView) otherwise.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @ref Containers::NullOpt. Expects that a filesystem is opened.
+         */
+        Containers::Optional<std::size_t> size();
+
+        /**
+         * @brief File size
+         * @m_since_latest
+         *
+         * Available only if @ref FilesystemFeature::Files is supported. Use
+         * @ref size() otherwise.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @ref Containers::NullOpt. Expects that a filesystem is opened.
+         */
+        Containers::Optional<std::size_t> size(Containers::StringView filename);
+
+        /*@}*/
+
+        /** @{ @name Data access */
+
+        /**
+         * @brief Read the whole filesystem contents
+         *
+         * Available only if @ref FilesystemFeature::Files is *not* supported,
+         * i.e. the filesystem is for example just a compressed data stream.
+         * Use @ref read(Containers::StringView) otherwise.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @ref Containers::NullOpt. Expects that a filesystem is opened.
+         */
+        Containers::Optional<Containers::Array<char>> read();
+
+        /**
+         * @brief Read a file
+         *
+         * Available only if @ref FilesystemFeature::Files is supported. Use
+         * @ref read() otherwise.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @ref Containers::NullOpt. Expects that a filesystem is opened.
+         */
+        Containers::Optional<Containers::Array<char>> read(Containers::StringView file);
+
+        /**
+         * @brief Map the whole filesystem contents
+         *
+         * Available only if @ref FilesystemFeature::Map is supported and
+         * @ref FilesystemFeature::Files is *not* supported, i.e. the
+         * filesystem is for example just a compressed data stream.
+         * Use @ref mapRead(Containers::StringView) otherwise.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @ref Containers::NullOpt. Expects that a filesystem is opened.
+         */
+        Containers::Optional<Containers::Array<const char, MapDeleter>> mapRead();
+
+        /**
+         * @brief Map a file
+         *
+         * Available only if @ref FilesystemFeature::Map and
+         * @ref FilesystemFeature::Files is supported. If
+         * @ref FilesystemFeature::Files is not supported, use @ref mapRead()
+         * otherwise.
+         *
+         * On failure prints a message to @ref Utility::Error and returns
+         * @ref Containers::NullOpt. Expects that a filesystem is opened.
+         */
+        Containers::Optional<Containers::Array<const char, MapDeleter>> mapRead(Containers::StringView file);
+        // TODO document that MapDeleter likely relies on the plugin being loaded
+
+        /*@}*/
+
+    private:
+        /** @brief Implementation for @ref features() */
+        virtual FilesystemFeatures doFeatures() const = 0;
+
+        /** @brief Implementation for @ref isOpened() */
+        virtual bool doIsOpened() = 0;
+
+        /** @brief Implementation for @ref openPath() */
+        virtual void doOpenPath(Containers::StringView path);
+
+        /** @brief Implementation for @ref openData() */
+        virtual void doOpenData(Containers::Array<const void> data);
+
+        /** @brief Implementation for @ref openMemory() */
+        virtual void doOpenMemory(Containers::ArrayView<const void> data);
+
+        /** @brief Implementation for @ref close() */
+        virtual void doClose() = 0;
+
+        /** @brief Implementation for @ref currentDirectory() */
+        virtual Containers::String doCurrentDirectory();
+
+        /** @brief Implementation for @ref setCurrentDirectory() */
+        virtual bool doSetCurrentDirectory(Containers::StringView path);
+
+        /** @brief Implementation for @ref exists() */
+        virtual bool doExists(Containers::StringView file);
+
+        /** @brief Implementation for @ref isDirectory() */
+        virtual bool doIsDirectory(Containers::StringView file);
+
+        /** @brief Implementation for @ref list(FilesystemListFlags) */
+        virtual Containers::Optional<Containers::Array<Containers::String>> doList(FilesystemListFlags flags);
+
+        /** @brief Implementation for @ref list(Containers::StringView, FilesystemListFlags) */
+        virtual Containers::Optional<Containers::Array<Containers::String>> doList(Containers::StringView path, FilesystemListFlags flags);
+
+        /** @brief Implementation for @ref size() */
+        virtual Containers::Optional<std::size_t> doSize();
+
+        /** @brief Implementation for @ref size(Containers::StringView) */
+        virtual Containers::Optional<std::size_t> doSize(Containers::StringView);
+
+        /** @brief Implementation for @ref read() */
+        virtual Containers::Optional<Containers::Array<char>> doRead();
+
+        /** @brief Implementation for @ref read(Containers::StringView) */
+        virtual Containers::Optional<Containers::Array<char>> doRead(Containers::StringView file);
+
+        /** @brief Implementation for @ref mapRead() */
+        virtual Containers::Optional<Containers::Array<char, MapDeleter>> doMapRead();
+
+        /** @brief Implementation for @ref mapRead(Containers::StringView) */
+        virtual Containers::Optional<Containers::Array<char, MapDeleter>> doMapRead(Containers::StringView file);
+};
+
+/**
+@brief Filesystem plugin interface
+@m_since_latest
+
+Same string as returned by
+@relativeref{Corrade::Filesystem,AbstractFilesystem::pluginInterface()}, meant
+to be used inside @ref CORRADE_PLUGIN_REGISTER() to avoid having to update the
+interface string by hand every time the version gets bumped:
+
+@snippet Filesystem.cpp CORRADE_FILESYSTEM_ABSTRACTFILESYSTEM_PLUGIN_INTERFACE
+
+The interface string version gets increased on every ABI break to prevent
+silent crashes and memory corruption. Plugins built against the previous
+version will then fail to load, a subsequent rebuild will make them pick up the
+updated interface string.
+*/
+/* Silly indentation to make the string appear in pluginInterface() docs */
+#define CORRADE_FILESYSTEM_ABSTRACTFILESYSTEM_PLUGIN_INTERFACE /* [interface] */ \
+"cz.mosra.corrade.Filesystem.AbstractFilesystem/0.1"
+/* [interface] */
+
+}}
+
+#endif

--- a/src/Corrade/Filesystem/CMakeLists.txt
+++ b/src/Corrade/Filesystem/CMakeLists.txt
@@ -1,0 +1,86 @@
+#
+#   This file is part of Corrade.
+#
+#   Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+#               2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025
+#             Vladimír Vondruš <mosra@centrum.cz>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+# IDE folder in VS, Xcode etc. CMake 3.12+, older versions have only the FOLDER
+# property that would have to be set on each target separately.
+set(CMAKE_FOLDER "Corrade/Filesystem")
+
+set(CorradeFilesystem_SRCS
+    AbstractFilesystem.cpp)
+
+set(CorradeFilesystem_HEADERS
+    AbstractFilesystem.h
+    Filesystem.h
+    visibility.h)
+
+# Objects shared between main and test library
+add_library(CorradeFilesystemObjects OBJECT
+    ${CorradeFilesystem_SRCS}
+    ${CorradeFilesystem_HEADERS}
+    ${CorradeFilesystem_PRIVATE_HEADERS})
+target_include_directories(CorradeFilesystemObjects PUBLIC $<TARGET_PROPERTY:CorradeUtility,INTERFACE_INCLUDE_DIRECTORIES>)
+if(NOT CORRADE_BUILD_STATIC)
+    target_compile_definitions(CorradeFilesystemObjects PRIVATE "-DCorradeTestSuiteObjects_EXPORTS")
+endif()
+if(NOT CORRADE_BUILD_STATIC OR CORRADE_BUILD_STATIC_PIC)
+    set_target_properties(CorradeFilesystemObjects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+
+# Main Filesystem library
+add_library(CorradeFilesystem ${SHARED_OR_STATIC}
+    $<TARGET_OBJECTS:CorradeFilesystemObjects>
+    ${_CORRADE_OBJECT_ONLY_TARGET_DUMMY_CPP}) # XCode workaround
+set_target_properties(CorradeFilesystem PROPERTIES
+    DEBUG_POSTFIX "-d")
+if(NOT CORRADE_BUILD_STATIC)
+    set_target_properties(CorradeFilesystem PROPERTIES VERSION ${CORRADE_LIBRARY_VERSION} SOVERSION ${CORRADE_LIBRARY_SOVERSION})
+elseif(CORRADE_BUILD_STATIC_PIC)
+    set_target_properties(CorradeFilesystem PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+target_link_libraries(CorradeFilesystem PUBLIC CorradePluginManager)
+
+install(TARGETS CorradeFilesystem
+        RUNTIME DESTINATION ${CORRADE_BINARY_INSTALL_DIR}
+        LIBRARY DESTINATION ${CORRADE_LIBRARY_INSTALL_DIR}
+        ARCHIVE DESTINATION ${CORRADE_LIBRARY_INSTALL_DIR})
+install(FILES ${CorradeFilesystem_HEADERS} DESTINATION ${CORRADE_INCLUDE_INSTALL_DIR}/Filesystem)
+
+if(CORRADE_BUILD_TESTS)
+    add_library(CorradeFilesystemTestLib ${SHARED_OR_STATIC} ${EXCLUDE_FROM_ALL_IF_TEST_TARGET}
+        $<TARGET_OBJECTS:CorradeFilesystemObjects>
+        ${_CORRADE_OBJECT_ONLY_TARGET_DUMMY_CPP}) # XCode workaround
+    target_include_directories(CorradeFilesystemTestLib PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+    set_target_properties(CorradeFilesystemTestLib PROPERTIES DEBUG_POSTFIX "-d")
+    if(CORRADE_BUILD_STATIC_PIC)
+        set_target_properties(CorradeFilesystemTestLib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    endif()
+    target_link_libraries(CorradeFilesystemTestLib PUBLIC CorradePluginManager)
+
+    add_subdirectory(Test ${EXCLUDE_FROM_ALL_IF_TEST_TARGET})
+endif()
+
+# Corrade::Filesystem target alias for superprojects
+add_library(Corrade::Filesystem ALIAS CorradeFilesystem)

--- a/src/Corrade/Filesystem/Filesystem.h
+++ b/src/Corrade/Filesystem/Filesystem.h
@@ -1,0 +1,43 @@
+#ifndef Corrade_Fs_AbstractFilesystem_h
+#define Corrade_Fs_AbstractFilesystem_h
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Forward declarations for the @ref Corrade::Filesystem namespace
+ */
+
+#include "Corrade/configure.h"
+
+#ifndef DOXYGEN_GENERATING_OUTPUT
+namespace Corrade { namespace Filesystem {
+
+class AbstractFilesystem;
+
+}}
+#endif
+
+#endif

--- a/src/Corrade/Filesystem/visibility.h
+++ b/src/Corrade/Filesystem/visibility.h
@@ -1,0 +1,49 @@
+#ifndef Corrade_Filesystem_visibility_h
+#define Corrade_Filesystem_visibility_h
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Corrade/configure.h"
+#include "Corrade/Utility/VisibilityMacros.h"
+
+#ifndef DOXYGEN_GENERATING_OUTPUT
+#ifndef CORRADE_BUILD_STATIC
+    #if defined(CorradeFilesystem_EXPORTS) || defined(CorradeFilesystemObjects_EXPORTS) || defined(CorradeFilesystemTestLib_EXPORTS)
+        #define CORRADE_FILESYSTEM_EXPORT CORRADE_VISIBILITY_EXPORT
+    #else
+        #define CORRADE_FILESYSTEM_EXPORT CORRADE_VISIBILITY_IMPORT
+    #endif
+#else
+    #define CORRADE_FILESYSTEM_EXPORT CORRADE_VISIBILITY_STATIC
+#endif
+#define CORRADE_FILESYSTEM_LOCAL CORRADE_VISIBILITY_LOCAL
+#else
+#define CORRADE_FILESYSTEM_EXPORT
+#define CORRADE_FILESYSTEM_LOCAL
+#endif
+
+#endif
+


### PR DESCRIPTION
A "one line" marketing pitch (*everything* subject to change):

```cpp
PluginManager::Manager<Fs::Filesystem> manager;

std::unique_ptr<Fs::Filesystem> fs = manager.loadAndInstantiate("AnyFilesystem");

fs->openPrefix("http://your.domain/assets/");            // web 
fs->openPrefix("bundle://assets/");                      // android
fs->openPrefix("assets.zip");                            // local filesystem
fs->openPrefix("://assets.zip");                         // compiled-in resource
fs->openPrefix("http://your.domain/assets/assets.zip");  // or combined

// map the file, if supported
Containers::Array<char, Fs::MapDeleter> data = fs->map("file.jpg");

// or just copy-read
Containers::Array<char> data = fs->read("file.jpg");
```

Further info: https://gist.github.com/mosra/d64d4388d6a3bef80c6226ea6b479d6d

Things to do, based on the comments below and further research on my side:

- [ ] All APIs taking a path string should also take a list of path items, useful when the path is generated programatically
  - [ ] Ability to open a file by inode/GUID/sha1, to sidestep all string processing
- [ ] Have both blocking and non-blocking (callback-based / poll-based) IO. Blocking is more convenient for simple uses in tools (`magnum-player`), non-blocking on platforms where async is the default (Emscripten, HTTP downloads).
  - [ ] Have a `Features` enum advertising each, checking that only allowed APIs are used
  - [ ] Or have `AbstractFilesystem` provide convenience wrappers to turn one into the other? I.e., spinning a thread to turn a blocking IO to async, do a "spin loop" waiting for the async for the inverse?
- [ ] Ability to [batch syscalls](https://twitter.com/matiasgoldberg/status/950134047707197440) -- memory mapping? something?
- [ ] API for filesystem notifications (like `Utility::FileWatcher`, but generalized)
- [ ] Layered filesystems (like CPU L1/L2/L3 caches), transparently preferring a local/faster access over browser cache over a network etc. Which is basically an ability to "merge" multiple filesystem into each, with some configurable conflict resolution policy.
- [ ] On-the-fly seekable ZIP decompression using pagefault callbacks (http://tech.nextroll.com/blog/data/2016/11/29/traildb-mmap-s3.html, https://lwn.net/Articles/550555/, macOS should have something also)
  - seekable gzip: https://github.com/pauldmccarthy/indexed_gzip
  - a detailed ZIP implementation article: https://www.hanshq.net/zip.html
  - zstd seeking: https://github.com/facebook/zstd/tree/dev/contrib/seekable_format
  - https://github.com/martinellimarco/libzstd-seek
  - other formats: https://github.com/mxmlnkn/ratarmount
- [ ] Cross-platform support for something like https://github.com/wbenny/woftool
- [ ] A custom "memory-map the web" FS (https://www.osnews.com/story/131383/googles-new-incremental-file-system-may-let-you-play-big-android-games-before-theyre-fully-downloaded/ )

Further ideas:

- [ ] A wrapper over win32 resources (EnumResources, FindResource, LoadResource, LockResource + GetResourceSize), exposing them as a filesystem
- [ ] A wrapper over `Utility::Resource`, exposing it as a filesystem
- [ ] Hugepages support for faster memory reservation when memory-mapping -- https://chrisgreendevelopmentblog.wordpress.com/2021/10/14/fun-with-large-memory-allocations-well-not-really-fun-at-all/
- [ ] Anything to take from https://github.com/cginternals/cppfs ? A bit of a kitchen sink library that includes also tree diffing or SHA1 calculation that doesn't really have a place in a pure FS abstraction lib...
- [ ] Decompression in-place, overwriting the compressed data https://twitter.com/ZoidCTF/status/1590137517072056320