### PR TITLE
[WIP] Fix ArrayView bool conversion

### DIFF
--- a/src/Corrade/Containers/Array.h
+++ b/src/Corrade/Containers/Array.h
@@ -328,7 +328,7 @@ class Array {
         /** @brief Whether the array is non-empty */
         /* Disabled on MSVC <= 2017 to avoid ambiguous operator+() when doing
            pointer arithmetic. */
-        explicit operator bool() const { return _data; }
+        explicit operator bool() const { return _size; }
         #endif
 
         /**

--- a/src/Corrade/Containers/ArrayView.h
+++ b/src/Corrade/Containers/ArrayView.h
@@ -148,7 +148,7 @@ template<class T> class ArrayView {
         /** @brief Whether the array is non-empty */
         /* Disabled on MSVC <= 2017 to avoid ambiguous operator+() when doing
            pointer arithmetic. */
-        explicit operator bool() const { return _data; }
+        explicit operator bool() const { return _size; }
         #endif
 
         /** @brief Conversion to array type */
@@ -497,7 +497,7 @@ template<std::size_t size_, class T> class StaticArrayView {
         /** @brief Whether the array is non-empty */
         /* Disabled on MSVC <= 2017 to avoid ambiguous operator+() when doing
            pointer arithmetic. */
-        explicit operator bool() const { return _data; }
+        constexpr explicit operator bool() const { return size_; }
         #endif
 
         /** @brief Conversion to array type */

--- a/src/Corrade/Containers/StaticArray.h
+++ b/src/Corrade/Containers/StaticArray.h
@@ -212,6 +212,13 @@ template<std::size_t size_, class T> class StaticArray {
         /** @brief Moving is not allowed */
         StaticArray<size_, T>& operator=(StaticArray<size_, T>&&) = delete;
 
+        #ifndef CORRADE_MSVC2017_COMPATIBILITY
+        /** @brief Whether the array is non-empty */
+        /* Disabled on MSVC <= 2017 to avoid ambiguous operator+() when doing
+           pointer arithmetic. */
+        constexpr explicit operator bool() const { return size_; }
+        #endif
+
         /**
          * @brief Convert to @ref ArrayView
          *

--- a/src/Corrade/Containers/Test/ArrayViewTest.cpp
+++ b/src/Corrade/Containers/Test/ArrayViewTest.cpp
@@ -43,6 +43,7 @@ struct ArrayViewTest: TestSuite::Tester {
     void constructVoid();
 
     void convertBool();
+    void convertBoolNullptr();
     void convertPointer();
     void convertConst();
     void convertVoid();
@@ -75,6 +76,7 @@ ArrayViewTest::ArrayViewTest() {
               &ArrayViewTest::constructVoid,
 
               &ArrayViewTest::convertBool,
+              &ArrayViewTest::convertBoolNullptr,
               &ArrayViewTest::convertPointer,
               &ArrayViewTest::convertConst,
               &ArrayViewTest::convertVoid,
@@ -202,6 +204,15 @@ void ArrayViewTest::convertBool() {
     CORRADE_VERIFY(!(std::is_convertible<VoidArrayView, int>::value));
 }
 
+void ArrayViewTest::convertBoolNullptr() {
+    /* Zero-sized slice of an array should convert to false, while three-item
+       array starting at 0 should convert to true. The documentation says
+       it returns true if nonempty. */
+    int a[7];
+    CORRADE_VERIFY(!(ArrayView{a, 0}));
+    CORRADE_VERIFY((ArrayView{nullptr, 5}));
+}
+
 void ArrayViewTest::convertPointer() {
     int a[7];
     ArrayView b = a;
@@ -321,22 +332,22 @@ void ArrayViewTest::sliceNullptr() {
     ArrayView a{nullptr, 5};
 
     ArrayView b = a.prefix(nullptr);
-    CORRADE_VERIFY(!b);
+    CORRADE_VERIFY(!b.begin());
     CORRADE_COMPARE(b.size(), 0);
 
     ArrayView c = a.suffix(nullptr);
-    CORRADE_VERIFY(!c);
+    CORRADE_VERIFY(!c.begin());
     CORRADE_COMPARE(c.size(), 5);
 
     int data[5];
     ArrayView d{data};
 
     ArrayView e = d.prefix(nullptr);
-    CORRADE_VERIFY(!e);
+    CORRADE_VERIFY(!e.begin());
     CORRADE_COMPARE(e.size(), 0);
 
     ArrayView f = d.suffix(nullptr);
-    CORRADE_VERIFY(!f);
+    CORRADE_VERIFY(!f.begin());
     CORRADE_COMPARE(f.size(), 0);
 }
 

--- a/src/Corrade/Containers/Test/StaticArrayViewTest.cpp
+++ b/src/Corrade/Containers/Test/StaticArrayViewTest.cpp
@@ -41,6 +41,7 @@ struct StaticArrayViewTest: TestSuite::Tester {
     void constructConst();
 
     void convertBool();
+    void convertBoolNullptr();
     void convertPointer();
     void convertConst();
     void convertVoid();
@@ -70,6 +71,7 @@ StaticArrayViewTest::StaticArrayViewTest() {
               &StaticArrayViewTest::constructConst,
 
               &StaticArrayViewTest::convertBool,
+              &StaticArrayViewTest::convertBoolNullptr,
               &StaticArrayViewTest::convertPointer,
               &StaticArrayViewTest::convertConst,
               &StaticArrayViewTest::convertVoid,
@@ -158,8 +160,19 @@ void StaticArrayViewTest::constructConst() {
 void StaticArrayViewTest::convertBool() {
     int a[7];
     CORRADE_VERIFY(StaticArrayView<5>{a});
-    CORRADE_VERIFY(!StaticArrayView<5>{});
+    /** @todo ISO C++ forbids zero-side array, can't really test */
+    //CORRADE_VERIFY(StaticArrayView<0>{});
     CORRADE_VERIFY(!(std::is_convertible<StaticArrayView<5>, int>::value));
+}
+
+void StaticArrayViewTest::convertBoolNullptr() {
+    /* Zero-sized slice of an array should convert to false, while three-item
+       array starting at 0 should convert to true. The documentation says
+       it returns true if nonempty. */
+    /** @todo ISO C++ forbids zero-side array, can't really test */
+    //int a[7];
+    //CORRADE_VERIFY(!StaticArrayView<5>{a}.slice<0>(1));
+    CORRADE_VERIFY(StaticArrayView<5>{nullptr});
 }
 
 void StaticArrayViewTest::convertPointer() {


### PR DESCRIPTION
The problem, in short:

```cpp
int a[5];
Debug{} << bool(ArrayView<int>{a}); // prints true, as expected
Debug{} << bool(ArrayView<int>{a, 4}); // prints true
Debug{} << bool(ArrayView<int>{a, 0}); // prints true .. huh?

Debug{} << bool(ArrayView<int>{nullptr}); // prints false, as expected
Debug{} << bool(ArrayView<int>{nullptr, 0}); // prints false
Debug{} << bool(ArrayView<int>{nullptr, 4}); // prints false .. huh?
```

In other words, currently `bool` conversion is done from the data pointer, not from the size pointer. I think it should depend on the size rather than on the data, to make life easier when writing parsers and such. The following code will cycle forever, because `input` is always some non-null pointer, even though size eventually becomes zero and one has to pay extra attention and say `!input.empty()` or something:

```cpp
ArrayView<const char> input; // some larger string

while(input) { // forever :(
    std::size_t bytesRead = ...;
    input = input.suffix(bytesRead);
}
```

That's not really intuitive, as e.g. `std::istream` also returns `false` when reaching EOF.

- - - 

So, fixing the bool conversion like this (as partially done in the PR already) seems like a good idea (for me at least), but there's one problem -- the bool conversion operator is disabled on MSVC as it causes ambiguities for `operator+`, basically clashing with the pointer conversion operator, even though the bool conversion is explicit (huh?). So there are the following options:

- [ ] Leave `explicit operator bool()` like it currently is (`return _data;`) and update the documentation to say it basically doesn't do what would one expect. That makes it consistent with MSVC, but practically useless and potentially dangerous if accidentally used for the wrong purpose.
- [ ] FIx it, but since it's disabled on MSVC, have totally different behavior there, causing code to break in unexpected ways. Wrong solution.
- [ ] Investigate and try to fix the ambiguity on MSVC. Might be impossible or might be possible only on MSVC 2017, leaving 2015 with the same dangerous inconsistency as above.
- [ ] Add an explicit branch to the constructor which sets the data pointer to `nullptr` in case size is zero. That makes it consistent with Array behavior, but might break some code. (I know about at least one case in the OpenDDL parse where I'm treating zero-sized nullptr view and zero-sized non-nullptr view differently -- the first one indicating a parse error, the second indicating EOF.)

To ensure consistency, this applies also to the `StaticArrayView`, but there zero-sized views are problematic at the moment due to some non-ISO-standard zero-sized arrays being present in function signatures.

Opinions? Thank you :)