### PR TITLE
Test corrade_add_resource() with Unicode filenames

### DIFF
--- a/src/Corrade/Utility/Test/CMakeLists.txt
+++ b/src/Corrade/Utility/Test/CMakeLists.txt
@@ -163,11 +163,18 @@ corrade_add_test(UtilityUnicodeTest UnicodeTest.cpp LIBRARIES CorradeUtilityTest
 corrade_add_resource(ResourceTestData ResourceTestFiles/resources.conf)
 corrade_add_resource(ResourceTestEmptyFileData ResourceTestFiles/resources-empty-file.conf)
 corrade_add_resource(ResourceTestNothingData ResourceTestFiles/resources-nothing.conf)
+
+# CMake < 3.1 can't handle UTF-8 in file(STRINGS)
+if(NOT CMAKE_VERSION VERSION_LESS 3.1)
+    corrade_add_resource(ResourceTestUtf8Data ResourceTestFiles/hýždě.conf)
+endif()
+
 corrade_add_test(UtilityResourceTest
     ResourceTest.cpp
     ${ResourceTestData}
     ${ResourceTestEmptyFileData}
     ${ResourceTestNothingData}
+    ${ResourceTestUtf8Data}
     LIBRARIES CorradeUtilityTestLib
     FILES
         ResourceTestFiles/compiled.cpp
@@ -194,6 +201,11 @@ corrade_add_test(UtilityResourceTest
         ResourceTestFiles/resources-overriden-none.conf
         ResourceTestFiles/resources-overriden-nonexistent-file.conf)
 target_include_directories(UtilityResourceTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+# CMake < 3.1 can't handle UTF-8 in file(STRINGS), disable relevant test case
+if(CMAKE_VERSION VERSION_LESS 3.1)
+    target_compile_definitions(UtilityResourceTest PRIVATE "RESOURCETETST_NO_UNICODE")
+endif()
 
 # Static lib resource test
 add_library(ResourceTestDataLib STATIC ${ResourceTestData})

--- a/src/Corrade/Utility/Test/ResourceTest.cpp
+++ b/src/Corrade/Utility/Test/ResourceTest.cpp
@@ -56,6 +56,7 @@ struct ResourceTest: TestSuite::Tester {
     void getEmptyFile();
     void getNonexistent();
     void getNothing();
+    void getUtf8Filename();
 
     void overrideGroup();
     void overrideGroupFallback();
@@ -83,6 +84,7 @@ ResourceTest::ResourceTest() {
               &ResourceTest::getEmptyFile,
               &ResourceTest::getNonexistent,
               &ResourceTest::getNothing,
+              &ResourceTest::getUtf8Filename,
 
               &ResourceTest::overrideGroup,
               &ResourceTest::overrideGroupFallback,
@@ -237,6 +239,17 @@ void ResourceTest::getNothing() {
     Resource r("nothing");
     CORRADE_VERIFY(out.str().empty());
     CORRADE_VERIFY(r.get("nonexistentFile").empty());
+}
+
+void ResourceTest::getUtf8Filename() {
+    #ifdef RESOURCETETST_NO_UNICODE
+    CORRADE_SKIP("CMake < 3.1 used, can't test compilation of resources with UTF-8 filenames.");
+    #else
+    Resource r("unicode");
+    CORRADE_COMPARE_AS(r.get("hýždě.bin"),
+        Directory::join(RESOURCE_TEST_DIR, "hýždě.bin"),
+        TestSuite::Compare::StringToFile);
+    #endif
 }
 
 void ResourceTest::overrideGroup() {


### PR DESCRIPTION
While everything works great on Linux and macOS, this causes CMake with Ninja on Windows to go into an infinite loop. As far as I know, this didn't happen with MinGW makefiles, so shouldn't be an issue with my CMake dependency handling code.

Putting this here so it doesn't get forgotten.