### PR TITLE
Source location in Debug

### DIFF
--- a/doc/corrade-changelog.dox
+++ b/doc/corrade-changelog.dox
@@ -45,6 +45,12 @@ namespace Corrade {
     existing @ref Containers::ArrayView<void> and
     @ref Containers::ArrayView<const void> types
 
+@subsubsection corrade-changelog-latest-new-utility Utility library
+
+-   Ability to optionally prefix @ref Utility::Debug output with a source file
+    and line on supported compilers. See @ref Utility-Debug-source-location for
+    more information.
+
 @subsection corrade-changelog-latest-changes Changes and improvements
 
 @subsubsection corrade-changelog-latest-changes-containers Containers library

--- a/doc/snippets/Utility.cpp
+++ b/doc/snippets/Utility.cpp
@@ -380,6 +380,19 @@ Utility::Debug{} << "this has default color again";
 }
 
 {
+/* [Debug-source-location] */
+float a = 336;
+
+!Utility::Debug{} << "the result is" << (a /= 8);
+!Utility::Debug{} << "but here it's" << (a /= 8);
+
+!Utility::Debug{};
+
+Utility::Debug{} << "and finally, " << (a *= 8);
+/* [Debug-source-location] */
+}
+
+{
 /* [Debug-nospace] */
 Utility::Debug{} << "Value:" << 16 << Utility::Debug::nospace << "," << 24;
 /* [Debug-nospace] */

--- a/src/Corrade/Corrade.h
+++ b/src/Corrade/Corrade.h
@@ -323,6 +323,16 @@ the console. This is done automatically when you link to the
 */
 #define CORRADE_UTILITY_USE_ANSI_COLORS
 #undef CORRADE_UTILITY_USE_ANSI_COLORS
+
+/**
+@brief Source location support in debug output
+
+Defined if @ref Corrade::Utility::Debug "Utility::Debug" is able to print
+source location support. Available only on GCC 8.1 and newer. See
+@ref Utility-Debug-source-location for more information.
+*/
+#define CORRADE_UTILITY_DEBUG_HAS_SOURCE_LOCATION
+#undef CORRADE_UTILITY_DEBUG_HAS_SOURCE_LOCATION
 #endif
 
 }

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -91,6 +91,8 @@ struct DebugTest: TestSuite::Tester {
     #ifndef CORRADE_TARGET_EMSCRIPTEN
     void multithreaded();
     #endif
+
+    void sourceLocation();
 };
 
 DebugTest::DebugTest() {
@@ -158,7 +160,8 @@ DebugTest::DebugTest() {
         #ifndef CORRADE_TARGET_EMSCRIPTEN
         &DebugTest::multithreaded,
         #endif
-        });
+
+        &DebugTest::sourceLocation});
 }
 
 void DebugTest::debug() {
@@ -934,6 +937,36 @@ void DebugTest::multithreaded() {
     #endif
 }
 #endif
+
+void DebugTest::sourceLocation() {
+    std::ostringstream out;
+
+    {
+        Debug redirect{&out};
+
+        !Debug{} << "hello";
+
+        !Debug{} << "and this is from another line";
+
+        !Debug{};
+
+        Debug{} << "this no longer";
+    }
+
+    #ifdef CORRADE_UTILITY_DEBUG_HAS_SOURCE_LOCATION
+    CORRADE_COMPARE(out.str(),
+        __FILE__ ":947: hello\n"
+        __FILE__ ":949: and this is from another line\n"
+        __FILE__ ":951\n"
+        "this no longer\n");
+    #else
+    CORRADE_COMPARE(out.str(),
+        "hello\n"
+        "and this is from another line\n"
+        "this no longer\n");
+    CORRADE_SKIP("Source location builtins not available.");
+    #endif
+}
 
 }}}}
 

--- a/src/Corrade/configure.h.cmake
+++ b/src/Corrade/configure.h.cmake
@@ -111,4 +111,9 @@
 /* Otherwise no idea. */
 #endif
 
+/* Source location support in Debug */
+#if (defined(__GNUC__) && __GNUC__*100 + __GNUC_MINOR__ >= 801) || (defined(__clang__) && __clang_major__ >= 9)
+#define CORRADE_UTILITY_DEBUG_HAS_SOURCE_LOCATION
+#endif
+
 #endif

--- a/src/Corrade/configure.h.cmake
+++ b/src/Corrade/configure.h.cmake
@@ -111,8 +111,10 @@
 /* Otherwise no idea. */
 #endif
 
-/* Source location support in Debug */
-#if (defined(__GNUC__) && __GNUC__*100 + __GNUC_MINOR__ >= 801) || (defined(__clang__) && __clang_major__ >= 9)
+/* Source location support in Debug. Since GCC 8.1 and Clang 9+, which is
+   (hopefully) going to be Apple Clang 12. Using __apple_build_version__
+   according to https://stackoverflow.com/a/19391724 to distinguish. */
+#if (defined(__GNUC__) && __GNUC__*100 + __GNUC_MINOR__ >= 801) || (defined(__clang__) && ((defined(__apple_build_version__) && __clang_major__ >= 12) || (!defined(__apple_build_version__) && __clang_major__ >= 9)))
 #define CORRADE_UTILITY_DEBUG_HAS_SOURCE_LOCATION
 #endif
 


### PR DESCRIPTION
Similarly to the [new `dbg!` macro in Rust](https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html#the-dbg-macro), this implements source location for Debug using [std::experiemntal::source_location](https://en.cppreference.com/w/cpp/experimental/source_location). At the moment this feature is present only in GCC 8.1 / libstdc++ and up and a builtin in Clang 9:

- ~~no traces of `std::source_location` in libc++ yet as of November: https://github.com/llvm-mirror/libcxx/tree/master/include/experimental~~ using the builtins instead
- feature request for MSVC (it apparently won't be in C++20?): https://developercommunity.visualstudio.com/idea/354069/implement-c-library-fundamentals-ts-v2.html, tracking issue: https://github.com/microsoft/STL/issues/54

This is an experiment that needs further design iterations:

- [x] ~~At the moment, all `Debug{}`, `Error{}` etc. constructors are acquiring the source location and saving it even if it might not be used, which means *extreme* increase in binary sizes. While this is convenient and doesn't require changes on the user side (it's just enabling a flag and then all following debug statements in the same scope get source location), it's not efficient. Some ideas:~~
  - ~~Provide a dedicated function such as `debug()` that instantiates `Debug` and with source location (bad, it requires users to learn a new thing, also we would need to do an `error()`, `fatal()` etc. and there's a high chance these names will clash with user code)~~
  - ~~Provide a constructor tag such as `Debug{Debug::SourceLocation}` (again kinda bad, since it's verbose to say every time)~~
  - ~~Save source file name only at the point of enabling the debug output but save line in every constructor (would need some way to detect what file we are in in order to *not* print file info from unrelated files, maybe abusing unnamed namespaces?)~~
  - ~~Provide a constructor tag that explicitly does not use source location and then use that in all the library internals to minimize the impact (goes against "don't pay for what you don't use", doesn't really help users)~~
  - Use `!Debug{}` 
- [x] ~~The Rust `dbg!` macro works inside `if()` as well, provide something like that too?~~ not sure how
- [x] The GCC implementation requires C++14, ~~I'm working around that by `#undef constexpr` for C++11 (which is insane), submit a PR to libstdc++ that uses some C++14 constexpr instead?~~ -- using the builtins directly
- [x] ~~The file+line info output format is probably not the best (use colors? wrap in `[]` like Rust does? make it `format()`able, allowing stuff like column, date and other things there?)~~ postponed, will be done together with arbitrary line prefixing
- [x] Some way to print just file & line without anything else [like Rust 1.35 has](https://blog.rust-lang.org/2019/05/23/Rust-1.35.0.html#calling-dbg()-with-no-argument)

Obligatory docs:

![image](https://user-images.githubusercontent.com/344828/60261548-6ff40180-98dc-11e9-845a-c92ae50a10fe.png)

Further design ideas welcome! :)