### PR TITLE
 Packages: Add Conan support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ CMakeLists.txt.user*
 .DS_Store
 *.swp
 *~
-package/conan/test_package/build/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ CMakeLists.txt.user*
 .DS_Store
 *.swp
 *~
+package/conan/test_package/build/*

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class CorradeConan(ConanFile):
                     graphics engine, among other things."
     # topics can get used for searches, GitHub topics, Bintray tags etc. Add here keywords about the library
     topics = ("conan", "corrad", "magnum", "filesystem", "console", "environment", "os")
-    url = "https://github.com/helmesjo/conan-corrade"
+    url = "https://github.com/mosra/corrade"
     homepage = "https://magnum.graphics/corrade"
     author = "helmesjo <helmesjo@gmail.com>"
     license = "MIT"  # Indicates license type of the packaged library; please use SPDX Identifiers https://spdx.org/licenses/

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
+import os
+import shutil
+
+
+def sort_libs(correct_order, libs, lib_suffix='', reverse_result=False):
+    # Add suffix for correct string matching
+    correct_order[:] = [s.__add__(lib_suffix) for s in correct_order]
+
+    result = []
+    for expectedLib in correct_order:
+        for lib in libs:
+            if expectedLib == lib:
+                result.append(lib)
+
+    if reverse_result:
+        # Linking happens in reversed order
+        result.reverse()
+
+    return result
+
+
+class CorradeConan(ConanFile):
+    name = "corrade"
+    version = "2018.10"
+    description = "Corrade is a multiplatform utility library written \
+                    in C++11/C++14. It's used as a base for the Magnum \
+                    graphics engine, among other things."
+    # topics can get used for searches, GitHub topics, Bintray tags etc. Add here keywords about the library
+    topics = ("conan", "corrad", "magnum", "filesystem", "console", "environment", "os")
+    url = "https://github.com/helmesjo/conan-corrade"
+    homepage = "https://magnum.graphics/corrade"
+    author = "helmesjo <helmesjo@gmail.com>"
+    license = "MIT"  # Indicates license type of the packaged library; please use SPDX Identifiers https://spdx.org/licenses/
+    exports = ["COPYING"]
+    exports_sources = ["CMakeLists.txt", "src/*", "package/conan/*", "modules/*"]
+    generators = "cmake"
+    short_paths = True  # Some folders go out of the 260 chars path length scope (windows)
+
+    # Options may need to change depending on the packaged library.
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "build_deprecated": [True, False],
+        "with_interconnect": [True, False],
+        "with_pluginmanager": [True, False],
+        "with_rc": [True, False],
+        "with_testsuite": [True, False],
+        "with_utility": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "build_deprecated": True,
+        "with_interconnect": True,
+        "with_pluginmanager": True,
+        "with_rc": True,
+        "with_testsuite": True,
+        "with_utility": True,
+    }
+
+    _build_subfolder = "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+
+    def configure(self):
+        if self.settings.compiler == 'Visual Studio' and int(self.settings.compiler.version.value) < 14:
+            raise ConanException("{} requires Visual Studio version 14 or greater".format(self.name))
+
+    def source(self):
+        # Wrap the original CMake file to call conan_basic_setup
+        shutil.move("CMakeLists.txt", "CMakeListsOriginal.txt")
+        shutil.move(os.path.join("package", "conan", "CMakeLists.txt"), "CMakeLists.txt")
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+
+        def add_cmake_option(option, value):
+            var_name = "{}".format(option).upper()
+            value_str = "{}".format(value)
+            var_value = "ON" if value_str == 'True' else "OFF" if value_str == 'False' else value_str
+            cmake.definitions[var_name] = var_value
+
+        for option, value in self.options.items():
+            add_cmake_option(option, value)
+
+        # Corrade uses suffix on the resulting 'lib'-folder when running cmake.install()
+        # Set it explicitly to empty, else Corrade might set it implicitly (eg. to "64")
+        add_cmake_option("LIB_SUFFIX", "")
+
+        add_cmake_option("BUILD_STATIC", not self.options.shared)
+
+        if self.settings.compiler == 'Visual Studio':
+            add_cmake_option("MSVC2015_COMPATIBILITY", int(self.settings.compiler.version.value) == 14)
+            add_cmake_option("MSVC2017_COMPATIBILITY", int(self.settings.compiler.version.value) == 17)
+
+        if self.settings.compiler == 'gcc':
+            add_cmake_option("GCC47_COMPATIBILITY", float(self.settings.compiler.version.value) < 4.8)
+
+        cmake.configure(build_folder=self._build_subfolder)
+
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=".")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        # See dependency order here: https://doc.magnum.graphics/magnum/custom-buildsystems.html
+        allLibs = [
+            #1
+            "CorradeUtility",
+            "CorradeContainers",
+            #2
+            "CorradeInterconnect",
+            "CorradePluginManager",
+            "CorradeTestSuite",
+        ]
+
+        # Sort all built libs according to above, and reverse result for correct link order
+        suffix = '-d' if self.settings.build_type == "Debug" else ''
+        builtLibs = tools.collect_libs(self)
+        self.cpp_info.libs = sort_libs(correct_order=allLibs, libs=builtLibs, lib_suffix=suffix, reverse_result=True)

--- a/package/conan/.gitignore
+++ b/package/conan/.gitignore
@@ -1,0 +1,1 @@
+test_package/build/*

--- a/package/conan/CMakeLists.txt
+++ b/package/conan/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+include(${CMAKE_SOURCE_DIR}/CMakeListsOriginal.txt)

--- a/package/conan/CMakeLists.txt
+++ b/package/conan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.0)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/package/conan/test_package/CMakeLists.txt
+++ b/package/conan/test_package/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(test_package)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+    	CXX_STANDARD 11
+    	CXX_STANDARD_REQUIRED ON
+    	CXX_EXTENSIONS OFF
+)

--- a/package/conan/test_package/CMakeLists.txt
+++ b/package/conan/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.0)
 project(test_package)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)

--- a/package/conan/test_package/conanfile.py
+++ b/package/conan/test_package/conanfile.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+
+from conans import ConanFile, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/package/conan/test_package/conanfile.py
+++ b/package/conan/test_package/conanfile.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
 
 from conans import ConanFile, CMake
 import os

--- a/package/conan/test_package/test_package.cpp
+++ b/package/conan/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <cstdlib>
+#include <Corrade/Utility/Debug.h>
+
+int main() {
+    Corrade::Utility::Debug() << "Success";
+
+    return EXIT_SUCCESS;
+}

--- a/package/conan/test_package/test_package.cpp
+++ b/package/conan/test_package/test_package.cpp
@@ -1,8 +1,7 @@
-#include <cstdlib>
 #include <Corrade/Utility/Debug.h>
 
 int main() {
     Corrade::Utility::Debug() << "Success";
 
-    return EXIT_SUCCESS;
+    return 0;
 }


### PR DESCRIPTION
Major work done by @helmesjo, thanks!

Also please review @helmesjo that I didn't make something stupid when adopting your version of the recipe 😄 

This is adding basic support for Conan. After merging this people can install and use Corrade by checking out this git repository and installing it via

`conan create . magnum/stable`

To make sure that the build was successful, the `test_package` should be executed in the same step via

`conan create . magnum/stable -tf package/conan/test_package`

(`-tf` stands for test folder)


________

This is not yet adding any CI/CD logic, which is mass building packages for all kinds of configurations and uploading these to a Conan repository. This should follow at a later step. In the meantime the Conan create command is always building Corrade from source automatically, as Conan is always doing when there aren't pre-build packages available for the own configuration.

________

Please don't forget to update the version number in the `conanfile.py` file before tagging a new release. In the future we can eliminate the hard coded version in the `conanfile.py`, but for now this makes things easier.

Cross-referencing: https://github.com/mosra/magnum/issues/304