### PR TITLE
Fixes compilation error on std=gnu++14

### DIFF
--- a/src/Corrade/PluginManager/AbstractPlugin.cpp
+++ b/src/Corrade/PluginManager/AbstractPlugin.cpp
@@ -35,7 +35,7 @@ struct AbstractPlugin::State {
     AbstractManager* manager{};
     std::string plugin;
     const PluginMetadata* metadata{};
-    Utility::ConfigurationGroup configuration;
+    Utility::ConfigurationGroup configuration{};
 };
 
 std::string AbstractPlugin::pluginInterface() { return {}; }


### PR DESCRIPTION
## Motivation and Context

On std=gnu++14, I get the following compile error:

```
[30/10/44  11% :: 8.5] Building CXX object src/Corrade/PluginManager/CMakeFiles/CorradePluginManagerObjects.dir/AbstractPlugin.cpp.o
FAILED: src/Corrade/PluginManager/CMakeFiles/CorradePluginManagerObjects.dir/AbstractPlugin.cpp.o
/Library/Developer/CommandLineTools/usr/bin/c++  -DCorradePluginManagerObjects_EXPORTS -I../src -Isrc -std=gnu++14 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk -fPIC   -Wall -Wextra -Wold-style-cast -Winit-self -Werror=return-type -Wmissing-declarations -pedantic -fvisibility=hidden -Wmissing-prototypes -Wno-shorten-64-to-32 -MD -MT src/Corrade/PluginManager/CMakeFiles/CorradePluginManagerObjects.dir/AbstractPlugin.cpp.o -MF src/Corrade/PluginManager/CMakeFiles/CorradePluginManagerObjects.dir/AbstractPlugin.cpp.o.d -o src/Corrade/PluginManager/CMakeFiles/CorradePluginManagerObjects.dir/AbstractPlugin.cpp.o -c ../src/Corrade/PluginManager/AbstractPlugin.cpp
In file included from ../src/Corrade/PluginManager/AbstractPlugin.cpp:26:
In file included from ../src/Corrade/PluginManager/AbstractPlugin.h:32:
../src/Corrade/Containers/Pointer.h:118:123: error: chosen constructor is explicit in copy-initialization
        template<class ...Args> explicit Pointer(InPlaceInitT, Args&&... args): _pointer{new T{std::forward<Args>(args)...}} {}
                                                                                                                          ^
../src/Corrade/PluginManager/AbstractPlugin.cpp:51:35: note: in instantiation of function template specialization 'Corrade::Containers::Pointer<Corrade::PluginManager::AbstractPlugin::State>::Pointer<>' requested here
AbstractPlugin::AbstractPlugin(): _state{Containers::InPlaceInit} {}
                                  ^
../src/Corrade/Utility/ConfigurationGroup.h:59:18: note: explicit constructor declared here
        explicit ConfigurationGroup();
                 ^
../src/Corrade/PluginManager/AbstractPlugin.cpp:38:33: note: in implicit initialization of field 'configuration' with omitted initializer
    Utility::ConfigurationGroup configuration;
                                ^
1 error generated.
[30/1/44  31% :: 10.3] Building CXX object src/Corrade/TestSuite/CMakeFiles/CorradeTestSuite.dir/Tester.cpp.o
ninja: build stopped: subcommand failed.
```

This PR explicitly initializes `configuration`, fixing this error.  On this PR, I can successfully build corrade (and all of magnum for that matter) with std=gnu++14

## How to repro

```
mkdir build && cd build
cmake -DCMAKE_CXX_FLAGS="-std=gnu++14" ..
make
```