### PR TITLE
[WIP] Interconnect: enable connecting stateful lambdas

### DIFF
--- a/src/Corrade/Interconnect/Emitter.h
+++ b/src/Corrade/Interconnect/Emitter.h
@@ -407,10 +407,10 @@ template<class ...Args> class FunctionConnectionData: public AbstractConnectionD
         const Slot _slot;
 };
 
-template<class ...Args> class AbstractLambdaConnection : public AbstractConnectionData {
+template<class ...Args> class AbstractLambdaConnectionData : public AbstractConnectionData {
 public:
 
-    template<class Emitter> explicit AbstractLambdaConnection(Emitter* emitter) : AbstractConnectionData{emitter, Type::CapturingLambda} {}
+    template<class Emitter> explicit AbstractLambdaConnectionData(Emitter* emitter) : AbstractConnectionData{emitter, Type::CapturingLambda} {}
 
 private:
     /* https://bugzilla.gnome.org/show_bug.cgi?id=776986 */
@@ -421,10 +421,10 @@ private:
     virtual void handle(Args... args) = 0;
 };
 
-template<class Lambda, class ...Args> class CapturingLambdaConnectionData : public AbstractLambdaConnection<Args...> {
+template<class Lambda, class ...Args> class CapturingLambdaConnectionData : public AbstractLambdaConnectionData<Args...> {
 public:
 
-    template<class Emitter> explicit CapturingLambdaConnectionData(Emitter* emitter, Lambda lambda) : AbstractLambdaConnection<Args...>{emitter}, _lambda{std::move(lambda)} {}
+    template<class Emitter> explicit CapturingLambdaConnectionData(Emitter* emitter, Lambda lambda) : AbstractLambdaConnectionData<Args...>{emitter}, _lambda{std::move(lambda)} {}
 
 private:
     /* https://bugzilla.gnome.org/show_bug.cgi?id=776986 */
@@ -567,7 +567,7 @@ template<class Emitter_, class ...Args> Emitter::Signal Emitter::emit(Signal(Emi
                     static_cast<Implementation::BaseMemberConnectionData<Args...>*>(it->second)->handle(args...);
                     break;
                 case Implementation::AbstractConnectionData::Type::CapturingLambda:
-                    static_cast<Implementation::AbstractLambdaConnection<Args...>*>(it->second)->handle(args...);
+                    static_cast<Implementation::AbstractLambdaConnectionData<Args...>*>(it->second)->handle(args...);
                     break;
                 default: CORRADE_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
             }

--- a/src/Corrade/Interconnect/Emitter.h
+++ b/src/Corrade/Interconnect/Emitter.h
@@ -479,10 +479,10 @@ template<class EmitterObject, class Emitter, class ...Args> Connection connect(E
 Overload for accepting function pointers and non-capturing lambdas (which are directly convertible to function pointers)
 @todo Why conversion of lambdas to function pointers is not done implicitly?
 */
-//template<class EmitterObject, class Emitter, class FunctionPointer, class ...Args>
-//typename std::enable_if<std::is_convertible<FunctionPointer, void(*)(Args...)>::value, Connection>::type connect(EmitterObject& emitter, Interconnect::Emitter::Signal(Emitter::*signal)(Args...), FunctionPointer slot) {
-//    return connect(emitter, signal, static_cast<void(*)(Args...)>(slot));
-//}
+template<class EmitterObject, class Emitter, class FunctionPointer, class ...Args>
+Connection connect(EmitterObject& emitter, Interconnect::Emitter::Signal(Emitter::*signal)(Args...), typename std::enable_if<std::is_convertible<FunctionPointer, void(*)(Args...)>::value, FunctionPointer>::type slot) {
+    return connect(emitter, signal, static_cast<void(*)(Args...)>(slot));
+}
 
 
 /** @relatesalso Emitter
@@ -490,10 +490,10 @@ Overload for accepting function pointers and non-capturing lambdas (which are di
 Overload for capturing lambdas
 */
 template<class EmitterObject, class Emitter, class Lambda, class ...Args>
-Connection connect(EmitterObject& emitter, Interconnect::Emitter::Signal(Emitter::*signal)(Args...), Lambda slot) {
+Connection connect(EmitterObject& emitter, Interconnect::Emitter::Signal(Emitter::*signal)(Args...), typename std::enable_if<!std::is_convertible<Lambda, void(*)(Args...)>::value, Lambda>::type slot) {
     static_assert(std::is_base_of<Emitter, EmitterObject>::value,
         "Emitter object doesn't have given signal");
-    //static_assert(!std::is_convertible<Lambda, void(*)(Args...)>::value, "Overload failure: Lambda type is convertible to function pointer, should use different overload!");
+    static_assert(!std::is_convertible<Lambda, void(*)(Args...)>::value, "Overload failure: Lambda type is convertible to function pointer, should use different overload!");
 
 #ifndef CORRADE_MSVC2017_COMPATIBILITY
     Implementation::SignalData signalData(signal);

--- a/src/Corrade/Interconnect/Test/Test.cpp
+++ b/src/Corrade/Interconnect/Test/Test.cpp
@@ -700,6 +700,17 @@ void Test::function() {
     connection.disconnect();
     postman.newMessage(0, "heyy");
     CORRADE_COMPARE(out.str(), "hello\n");
+
+    std::string receivedMessage{ "none" };
+    Connection connection2 = Interconnect::connect(postman, &Postman::newMessage, [&receivedMessage](int, const std::string&msg) { receivedMessage = msg; });
+    CORRADE_VERIFY(connection2.isConnectionPossible());
+    CORRADE_VERIFY(connection2.isConnected());
+
+    postman.newMessage(0, "hello");
+    CORRADE_COMPARE(receivedMessage, "hello");
+    connection2.disconnect();
+    postman.newMessage(0, "heyy");
+    CORRADE_COMPARE(receivedMessage, "hello\n");
 }
 
 }}}}

--- a/src/Corrade/Interconnect/Test/Test.cpp
+++ b/src/Corrade/Interconnect/Test/Test.cpp
@@ -707,10 +707,10 @@ void Test::function() {
     CORRADE_VERIFY(connection2.isConnected());
 
     postman.newMessage(0, "hello");
-    CORRADE_COMPARE(receivedMessage, "hello");
+    CORRADE_COMPARE(receivedMessage, "hello"); // "hello" should be received
     connection2.disconnect();
     postman.newMessage(0, "heyy");
-    CORRADE_COMPARE(receivedMessage, "hello\n");
+    CORRADE_COMPARE(receivedMessage, "hello"); // after disconnect, "hello" should still be there
 }
 
 }}}}


### PR DESCRIPTION
Previously, it was only possible to connect non-capturing lambdas. This should allow all lambdas to be connected through use of std::function.

i.e. this was not possible to do before:
```
    std::string receivedMessage{ "none" };
    Connection connection2 = Interconnect::connect(postman, &Postman::newMessage, [&receivedMessage](int, const std::string&msg) { receivedMessage = msg; });
```

This might lead to a drop in performance because of the added indirection of std::function. If this is a concern, it would probably be possible to find a SFINAE way to keep the old direct cast variant where applicable, and use the new pattern, however this would mean more complicated code. Also, modern compilers/STL implementations of std::function might be smart enough to detect and optimize the state-less case anyways?