### PR TITLE
Fixing gentoo build instructions

### DIFF
--- a/doc/building-corrade.dox
+++ b/doc/building-corrade.dox
@@ -265,7 +265,7 @@ install the package like this:
 @code{.sh}
 git clone git://github.com/mosra/corrade && cd corrade
 cd package/gentoo
-sudo ebuild dev-libs/corrade/corrade-99999.ebuild manifest clean merge
+sudo ebuild dev-libs/corrade/corrade-9999.ebuild manifest clean merge
 @endcode
 
 If you want to pass additional flags to CMake or


### PR DESCRIPTION
-99999 -> 9999 in the ebuild path