### PR TITLE
Utility/Debug: use thread_local for global state

### DIFF
--- a/src/Corrade/Utility/Debug.cpp
+++ b/src/Corrade/Utility/Debug.cpp
@@ -78,13 +78,13 @@ HANDLE streamOutputHandle(const std::ostream* s) {
 
 }
 
-std::ostream* Debug::_globalOutput = &std::cout;
-std::ostream* Warning::_globalWarningOutput = &std::cerr;
-std::ostream* Error::_globalErrorOutput = &std::cerr;
+thread_local std::ostream* Debug::_globalOutput = &std::cout;
+thread_local std::ostream* Warning::_globalWarningOutput = &std::cerr;
+thread_local std::ostream* Error::_globalErrorOutput = &std::cerr;
 
 #if !defined(CORRADE_TARGET_WINDOWS) || defined(CORRADE_UTILITY_USE_ANSI_COLORS)
-Debug::Color Debug::_globalColor = Debug::Color::Default;
-bool Debug::_globalColorBold = false;
+thread_local Debug::Color Debug::_globalColor = Debug::Color::Default;
+thread_local bool Debug::_globalColorBold = false;
 #endif
 
 template<Debug::Color c, bool bold> Debug::Modifier Debug::colorInternal() {

--- a/src/Corrade/Utility/Debug.cpp
+++ b/src/Corrade/Utility/Debug.cpp
@@ -76,13 +76,26 @@ HANDLE streamOutputHandle(const std::ostream* s) {
 }
 #endif
 
-thread_local std::ostream* globalOutput = &std::cout;
-thread_local std::ostream* globalWarningOutput = &std::cerr;
-thread_local std::ostream* globalErrorOutput = &std::cerr;
+/* Old versions of Apple Xcode do not support thread_local
+ * (but have __has_feature) */
+#ifdef __has_feature
+#if __has_feature(cxx_thread_local)
+#define THREAD_LOCAL thread_local
+#else
+#define THREAD_LOCAL __thread
+#endif
+#else
+/* assume it is present -- thread_local is more standardized than __thread */
+#define THREAD_LOCAL thread_local
+#endif
+
+THREAD_LOCAL std::ostream* globalOutput = &std::cout;
+THREAD_LOCAL std::ostream* globalWarningOutput = &std::cerr;
+THREAD_LOCAL std::ostream* globalErrorOutput = &std::cerr;
 
 #if !defined(CORRADE_TARGET_WINDOWS) || defined(CORRADE_UTILITY_USE_ANSI_COLORS)
-thread_local Debug::Color globalColor = Debug::Color::Default;
-thread_local bool globalColorBold = false;
+THREAD_LOCAL Debug::Color globalColor = Debug::Color::Default;
+THREAD_LOCAL bool globalColorBold = false;
 #endif
 
 }

--- a/src/Corrade/Utility/Debug.h
+++ b/src/Corrade/Utility/Debug.h
@@ -598,10 +598,10 @@ class CORRADE_UTILITY_EXPORT Debug {
     private:
         template<Color c, bool bold> CORRADE_UTILITY_LOCAL static Modifier colorInternal();
 
-        static CORRADE_UTILITY_LOCAL std::ostream* _globalOutput;
+        static thread_local CORRADE_UTILITY_LOCAL std::ostream* _globalOutput;
         #if !defined(CORRADE_TARGET_WINDOWS) || defined(CORRADE_UTILITY_USE_ANSI_COLORS)
-        static CORRADE_UTILITY_LOCAL Color _globalColor;
-        static CORRADE_UTILITY_LOCAL bool _globalColorBold;
+        static thread_local CORRADE_UTILITY_LOCAL Color _globalColor;
+        static thread_local CORRADE_UTILITY_LOCAL bool _globalColorBold;
         #endif
 
         CORRADE_UTILITY_LOCAL void resetColorInternal();
@@ -803,7 +803,7 @@ class CORRADE_UTILITY_EXPORT Warning: public Debug {
         Warning& operator=(Warning&&) = delete;
 
     private:
-        static CORRADE_UTILITY_LOCAL std::ostream* _globalWarningOutput;
+        static thread_local CORRADE_UTILITY_LOCAL std::ostream* _globalWarningOutput;
         std::ostream* _previousGlobalWarningOutput;
 };
 
@@ -885,7 +885,7 @@ class CORRADE_UTILITY_EXPORT Error: public Debug {
         CORRADE_UTILITY_LOCAL void cleanupOnDestruction(); /* Needed for Fatal */
 
     private:
-        static CORRADE_UTILITY_LOCAL std::ostream* _globalErrorOutput;
+        static thread_local CORRADE_UTILITY_LOCAL std::ostream* _globalErrorOutput;
         std::ostream* _previousGlobalErrorOutput;
 };
 

--- a/src/Corrade/Utility/Debug.h
+++ b/src/Corrade/Utility/Debug.h
@@ -598,12 +598,6 @@ class CORRADE_UTILITY_EXPORT Debug {
     private:
         template<Color c, bool bold> CORRADE_UTILITY_LOCAL static Modifier colorInternal();
 
-        static thread_local CORRADE_UTILITY_LOCAL std::ostream* _globalOutput;
-        #if !defined(CORRADE_TARGET_WINDOWS) || defined(CORRADE_UTILITY_USE_ANSI_COLORS)
-        static thread_local CORRADE_UTILITY_LOCAL Color _globalColor;
-        static thread_local CORRADE_UTILITY_LOCAL bool _globalColorBold;
-        #endif
-
         CORRADE_UTILITY_LOCAL void resetColorInternal();
 
         std::ostream* _previousGlobalOutput;
@@ -803,7 +797,6 @@ class CORRADE_UTILITY_EXPORT Warning: public Debug {
         Warning& operator=(Warning&&) = delete;
 
     private:
-        static thread_local CORRADE_UTILITY_LOCAL std::ostream* _globalWarningOutput;
         std::ostream* _previousGlobalWarningOutput;
 };
 
@@ -885,7 +878,6 @@ class CORRADE_UTILITY_EXPORT Error: public Debug {
         CORRADE_UTILITY_LOCAL void cleanupOnDestruction(); /* Needed for Fatal */
 
     private:
-        static thread_local CORRADE_UTILITY_LOCAL std::ostream* _globalErrorOutput;
         std::ostream* _previousGlobalErrorOutput;
 };
 


### PR DESCRIPTION
This allows using Debug/Warning/Error redirection in multi-threaded situations.

I roughly measured the performance impact on my system: 45ns (new) vs 37ns (old) for printing a single character (`Debug{} << "c"`), redirected into `std::stringstream`.
Benchmark code using https://github.com/david-grs/geiger is here: https://gist.github.com/xqms/d29764bcdeb0d0b49d5a4fd39497a4ec.

In my opinion the additional cost is worth the gain - especially since `Utility::Debug` is probably not used in perfomance-critical paths.