### PR TITLE
doc: Fix typo in corrade-cmake.dox

### DIFF
--- a/doc/corrade-cmake.dox
+++ b/doc/corrade-cmake.dox
@@ -282,7 +282,7 @@ corrade_add_plugin(<plugin name>
                    <sources>...)
 @endcode
 
-Unline the above version this puts everything into `<debug install dir>` on
+Unlike the above version this puts everything into `<debug install dir>` on
 both DLL and non-DLL platforms. If `<debug install dir>` is set to
 `CMAKE_CURRENT_BINARY_DIR` (e.g. for testing purposes), the files are copied
 directly, without the need to perform install step. Note that the files are


### PR DESCRIPTION
@mosra Just a tiny typo I found while reading docs.