### PR TITLE
modules: Fix test command when library output path is set

### DIFF
--- a/doc/corrade-changelog.dox
+++ b/doc/corrade-changelog.dox
@@ -48,6 +48,7 @@ namespace Corrade {
     @ref CORRADE_TARGET_DINKUMWARE macros to detect the common STL
     implementations
 -   New @ref CORRADE_BUILD_MULTITHREADED build-time option, moved from Magnum
+-   Fixed test execution command when library output path is set in CMake
 
 @subsubsection corrade-changelog-latest-new-containers Containers library
 

--- a/modules/UseCorrade.cmake
+++ b/modules/UseCorrade.cmake
@@ -401,7 +401,7 @@ function(corrade_add_test test_name)
 
         # Run tests natively elsewhere
         else()
-            add_test(${test_name} ${test_name} ${arguments})
+            add_test(NAME ${test_name} COMMAND ${test_name} ${arguments})
         endif()
 
         # iOS-specific


### PR DESCRIPTION
Hi @mosra !

This is a tiny one, but would help me with maintenance a bit if it were to be upstreamed :)

Best,
Jonathan

From the commit message:
~~~
E.g. when `LIBRARY_OUTPUT_PATH` is set globally or the target property
`LIBRARY_OUTPUT_DIRECTORY` is set.

add_test(<name> <command> <args>) does not resolve the target file, but
rather just runs the command, which works as long as it is where cmake
puts in by default, but not if the library output dir is modified.

add_test(NAME <name> COMMAND <command> <args>) on the other hand resolves
generator expressions and <command>, if an executable target, will
"automatically be replaced by the location of the executable created at
build time." (from the cmake docs.)
~~~