### PR TITLE
Fix corrade-rc executable not found when build target WinRT #81

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ endif()
 
 # Initialize macros etc.
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/modules/" ${CMAKE_MODULE_PATH})
-if(CMAKE_CROSSCOMPILING)
+if(CMAKE_CROSSCOMPILING AND NOT CORRADE_TARGET_WINDOWS_RT)
     find_program(CORRADE_RC_EXECUTABLE corrade-rc)
     if(NOT CORRADE_RC_EXECUTABLE)
         message(FATAL_ERROR "Native `corrade-rc` executable, which is needed when crosscompiling, was not found")

--- a/src/Corrade/Utility/CMakeLists.txt
+++ b/src/Corrade/Utility/CMakeLists.txt
@@ -181,7 +181,7 @@ endif()
 # Then the condition would be if(NOT CMAKE_CROSSCOMPILING OR CORRADE_TARGET_WINDOWS_RT)
 # and similar change would be in UseCorrade.cmake. More info in this thread:
 #  https://cmake.org/pipermail/cmake-developers/2015-January/024242.html
-if(NOT CMAKE_CROSSCOMPILING)
+if(NOT CMAKE_CROSSCOMPILING OR CORRADE_TARGET_WINDOWS_RT)
     # Sources for standalone corrade-rc
     set(CorradeUtilityRc_SRCS
         Arguments.cpp
@@ -227,6 +227,9 @@ if(NOT CMAKE_CROSSCOMPILING)
         target_link_libraries(corrade-rc PRIVATE ${CMAKE_DL_LIBS})
     endif()
     set_target_properties(corrade-rc PROPERTIES FOLDER "Corrade/Utility")
+    if(CORRADE_TARGET_WINDOWS_RT)
+        set_target_properties(corrade-rc PROPERTIES VS_WINRT_COMPONENT OFF)
+    endif()
     install(TARGETS corrade-rc DESTINATION ${CORRADE_BINARY_INSTALL_DIR})
 
     # Corrade::rc target alias for superprojects


### PR DESCRIPTION
building has passed on my machine.
but not sure what does "similar change would be in UseCorrade.cmake" mean in the TODO comment.