### PR TITLE
Utility: Minor improvements to Sha1 and AbstractHash

### DIFF
--- a/doc/snippets/Utility.cpp
+++ b/doc/snippets/Utility.cpp
@@ -33,6 +33,7 @@
 #include "Corrade/Utility/Arguments.h"
 #include "Corrade/Utility/Assert.h"
 #include "Corrade/Utility/Configuration.h"
+#include "Corrade/Utility/DebugStl.h"
 #include "Corrade/Utility/Directory.h"
 #if defined(CORRADE_TARGET_UNIX) || (defined(CORRADE_TARGET_WINDOWS) && !defined(CORRADE_TARGET_WINDOWS_RT)) || defined(CORRADE_TARGET_EMSCRIPTEN)
 #include "Corrade/Utility/FileWatcher.h"
@@ -40,6 +41,7 @@
 #include "Corrade/Utility/Format.h"
 #include "Corrade/Utility/FormatStl.h"
 #include "Corrade/Utility/Macros.h"
+#include "Corrade/Utility/Sha1.h"
 
 /* [Tweakable-disable-header] */
 #define CORRADE_TWEAKABLE
@@ -604,6 +606,25 @@ struct {
     float x, y;
 } position;
 };
+}
+
+{
+/* [Sha1-usage] */
+Utility::Sha1 sha1;
+
+/* Add 7 bytes of string data */
+sha1 << std::string{"corrade"};
+
+/* Add four bytes of binary data */
+const char data[] = { '\x35', '\xf6', '\x00', '\xab' };
+sha1 << Containers::arrayView(data);
+
+/* Print the digest as a hex string */
+Utility::Debug{} << sha1.digest().hexString();
+
+/* Shorthand variant */
+Utility::Debug{} << Utility::Sha1::digest("corrade");
+/* [Sha1-usage] */
 }
 }
 

--- a/src/Corrade/Utility/AbstractHash.h
+++ b/src/Corrade/Utility/AbstractHash.h
@@ -32,7 +32,6 @@
 #include <string>
 
 #include "Corrade/Utility/Debug.h"
-#include "Corrade/Utility/DebugStl.h"
 
 namespace Corrade { namespace Utility {
 
@@ -118,7 +117,7 @@ template<std::size_t digestSize> class AbstractHash {
 
 /** @debugoperator{HashDigest} */
 template<std::size_t size> inline Debug& operator<<(Debug& debug, const HashDigest<size>& value) {
-    return debug << value.hexString();
+    return debug << value.hexString().data();
 }
 
 template<std::size_t size> HashDigest<size> HashDigest<size>::fromHexString(std::string digest) {

--- a/src/Corrade/Utility/Sha1.cpp
+++ b/src/Corrade/Utility/Sha1.cpp
@@ -52,7 +52,7 @@ unsigned int leftrotate(unsigned int data, unsigned int shift) {
 
 Sha1::Sha1(): _dataSize(0), _digest{InitialDigest[0], InitialDigest[1], InitialDigest[2], InitialDigest[3], InitialDigest[4]} {}
 
-Sha1& Sha1::operator<<(const std::string& data) {
+Sha1& Sha1::operator<<(Containers::ArrayView<const char> data) {
     const std::size_t dataOffset = _buffer.empty() ? 0 : 64 - _buffer.size();
 
     /* Process leftovers */
@@ -65,7 +65,7 @@ Sha1& Sha1::operator<<(const std::string& data) {
         }
 
         /* Append few last bytes to have the buffer at 64 bytes */
-        _buffer.append(data.substr(0, dataOffset));
+        _buffer.append(data.prefix(dataOffset));
         processChunk(_buffer.data());
     }
 
@@ -73,10 +73,14 @@ Sha1& Sha1::operator<<(const std::string& data) {
         processChunk(data.data() + i);
 
     /* Save last unfinished 512-bit chunk of data */
-    _buffer = data.substr(dataOffset + ((data.size() - dataOffset)/64)*64);
+    _buffer = data.suffix(dataOffset + ((data.size() - dataOffset)/64)*64);
 
     _dataSize += data.size();
     return *this;
+}
+
+Sha1& Sha1::operator<<(const std::string& data) {
+    return *this << Containers::arrayView(data.data(), data.size());
 }
 
 /* GCC 6 (and possibly 7) on Raspberry Pi 3 Model B+ (aarch64) misoptimizes the

--- a/src/Corrade/Utility/Sha1.cpp
+++ b/src/Corrade/Utility/Sha1.cpp
@@ -26,6 +26,7 @@
 #include "Sha1.h"
 
 #include <cstddef>
+#include <string>
 
 #include "Corrade/Utility/Endianness.h"
 
@@ -50,31 +51,34 @@ unsigned int leftrotate(unsigned int data, unsigned int shift) {
 
 }
 
-Sha1::Sha1(): _dataSize(0), _digest{InitialDigest[0], InitialDigest[1], InitialDigest[2], InitialDigest[3], InitialDigest[4]} {}
+Sha1::Sha1(): _digest{InitialDigest[0], InitialDigest[1], InitialDigest[2], InitialDigest[3], InitialDigest[4]} {}
 
 Sha1& Sha1::operator<<(Containers::ArrayView<const char> data) {
-    const std::size_t dataOffset = _buffer.empty() ? 0 : 64 - _buffer.size();
+    const std::size_t dataOffset = _bufferSize ? 64 - _bufferSize : 0;
 
     /* Process leftovers */
-    if(!_buffer.empty()) {
+    if(_bufferSize != 0) {
         /* Not large enough, try it next time */
-        if(data.size() + _buffer.size() < 64) {
-            _buffer.append(data);
+        if(data.size() + _bufferSize < 64) {
+            std::memcpy(_buffer + _bufferSize, data.data(), data.size());
+            _bufferSize += data.size();
             _dataSize += data.size();
             return *this;
         }
 
         /* Append few last bytes to have the buffer at 64 bytes */
-        _buffer.append(data.prefix(dataOffset));
-        processChunk(_buffer.data());
+        std::memcpy(_buffer + _bufferSize, data.data(), dataOffset);
+        _bufferSize += dataOffset;
+        processChunk(_buffer);
     }
 
     for(std::size_t i = dataOffset; i + 64 <= data.size(); i += 64)
         processChunk(data.data() + i);
 
     /* Save last unfinished 512-bit chunk of data */
-    _buffer = data.suffix(dataOffset + ((data.size() - dataOffset)/64)*64);
-
+    auto leftOver = data.suffix(dataOffset + ((data.size() - dataOffset)/64)*64);
+    std::memcpy(_buffer, leftOver.data(), leftOver.size());
+    _bufferSize = leftOver.size();
     _dataSize += data.size();
     return *this;
 }
@@ -96,28 +100,35 @@ Sha1& Sha1::operator<<(const std::string& data) {
 #pragma GCC optimize ("O2")
 #endif
 Sha1::Digest Sha1::digest() {
-    /* Add '1' bit to the leftovers, pad to (n*64)+56 bytes */
-    _buffer.append(1, '\x80');
-    _buffer.append((_buffer.size() > 56 ? 120 : 56) - _buffer.size(), 0);
+    /* Add '1' bit to the leftovers */
+    _buffer[_bufferSize++] = '\x80';
+
+    /* Pad to (n*64)+56 bytes */
+    const size_t padding = (_bufferSize > 56 ? 120 : 56) - _bufferSize;
+    CORRADE_INTERNAL_ASSERT(_bufferSize + padding + 8 <= sizeof(_buffer));
+    std::memset(_buffer + _bufferSize, 0, padding);
+    _bufferSize += padding;
 
     /* Add size of data in bits in big endian */
     unsigned long long dataSizeBigEndian = Endianness::bigEndian<unsigned long long>(_dataSize*8);
-    _buffer.append(reinterpret_cast<const char*>(&dataSizeBigEndian), 8);
+    std::memcpy(_buffer + _bufferSize, reinterpret_cast<const char*>(&dataSizeBigEndian), 8);
+    _bufferSize += 8;
 
     /* Process remaining chunks */
-    for(std::size_t i = 0; i != _buffer.size()/64; ++i)
-        processChunk(_buffer.data()+i*64);
+    for(std::size_t i = 0; i != _bufferSize/64; ++i) {
+        processChunk(_buffer+i*64);
+    }
 
     /* Convert digest from big endian */
     unsigned int digest[5];
     for(int i = 0; i != 5; ++i)
         digest[i] = Endianness::bigEndian<unsigned int>(_digest[i]);
-    Digest d = Digest::fromByteArray(reinterpret_cast<const char*>(digest));
+    const Digest d = Digest::fromByteArray(reinterpret_cast<const char*>(digest));
 
     /* Clear data and return */
     std::copy(InitialDigest, InitialDigest+5, _digest);
-    _buffer.clear();
     _dataSize = 0;
+    _bufferSize = 0;
     return d;
 }
 #if defined(__GNUC__) && !defined(__clang__) && defined(CORRADE_TARGET_ARM) && __GNUC__ < 8

--- a/src/Corrade/Utility/Sha1.h
+++ b/src/Corrade/Utility/Sha1.h
@@ -36,7 +36,15 @@
 
 namespace Corrade { namespace Utility {
 
-/** @brief SHA-1 */
+/**
+@brief SHA-1
+
+Implementation of the [Secure Hash Algorithm 1](https://en.wikipedia.org/wiki/SHA-1).
+Example usage:
+
+@snippet Utility.cpp Sha1-usage
+
+*/
 class CORRADE_UTILITY_EXPORT Sha1: public AbstractHash<20> {
     public:
         /**
@@ -53,7 +61,11 @@ class CORRADE_UTILITY_EXPORT Sha1: public AbstractHash<20> {
         /** @brief Add data for digesting */
         Sha1& operator<<(Containers::ArrayView<const char> data);
 
-        /** @overload */
+        /**
+         * @overload
+         *
+         * The @cpp '\0' @ce delimiter is not included.
+         */
         Sha1& operator<<(const std::string& data);
 
         /** @overload */

--- a/src/Corrade/Utility/Sha1.h
+++ b/src/Corrade/Utility/Sha1.h
@@ -31,6 +31,7 @@
 
 #include <string>
 
+#include "Corrade/Containers/ArrayView.h"
 #include "Corrade/Utility/AbstractHash.h"
 #include "Corrade/Utility/visibility.h"
 
@@ -51,7 +52,16 @@ class CORRADE_UTILITY_EXPORT Sha1: public AbstractHash<20> {
         explicit Sha1();
 
         /** @brief Add data for digesting */
+        Sha1& operator<<(Containers::ArrayView<const char> data);
+
+        /** @overload */
         Sha1& operator<<(const std::string& data);
+
+        /** @overload */
+        template<std::size_t size>
+        Sha1& operator<<(const char(&data)[size]) {
+            return *this << Containers::arrayView(data, size);
+        }
 
         /** @brief Digest of all added data */
         Digest digest();

--- a/src/Corrade/Utility/Sha1.h
+++ b/src/Corrade/Utility/Sha1.h
@@ -68,10 +68,14 @@ class CORRADE_UTILITY_EXPORT Sha1: public AbstractHash<20> {
          */
         Sha1& operator<<(const std::string& data);
 
-        /** @overload */
-        template<std::size_t size> Sha1& operator<<(const char(&data)[size]) {
-            return *this << Containers::arrayView(data, size);
-        }
+        /**
+         * @brief @cpp operator<< @ce with string literals is not allowed
+         *
+         * Please explicitly cast to @ref Containers::ArrayView or
+         * @ref std::string instead. This ensures intentional exclusion
+         * or inclusion of the @cpp '\0' @ce delimiter.
+         */
+        Sha1& operator<<(const char*)=delete;
 
         /** @brief Digest of all added data */
         Digest digest();

--- a/src/Corrade/Utility/Sha1.h
+++ b/src/Corrade/Utility/Sha1.h
@@ -29,10 +29,9 @@
  * @brief Class @ref Corrade::Utility::Sha1
  */
 
-#include <string>
-
 #include "Corrade/Containers/ArrayView.h"
 #include "Corrade/Utility/AbstractHash.h"
+#include "Corrade/Utility/StlForwardString.h"
 #include "Corrade/Utility/visibility.h"
 
 namespace Corrade { namespace Utility {
@@ -58,8 +57,7 @@ class CORRADE_UTILITY_EXPORT Sha1: public AbstractHash<20> {
         Sha1& operator<<(const std::string& data);
 
         /** @overload */
-        template<std::size_t size>
-        Sha1& operator<<(const char(&data)[size]) {
+        template<std::size_t size> Sha1& operator<<(const char(&data)[size]) {
             return *this << Containers::arrayView(data, size);
         }
 
@@ -69,8 +67,9 @@ class CORRADE_UTILITY_EXPORT Sha1: public AbstractHash<20> {
     private:
         CORRADE_UTILITY_LOCAL void processChunk(const char* data);
 
-        std::string _buffer;
-        unsigned long long _dataSize;
+        char _buffer[128];
+        unsigned long long _bufferSize = 0;
+        unsigned long long _dataSize = 0;
         unsigned int _digest[5];
 };
 

--- a/src/Corrade/Utility/Test/HashDigestTest.cpp
+++ b/src/Corrade/Utility/Test/HashDigestTest.cpp
@@ -28,6 +28,7 @@
 #include "Corrade/TestSuite/Tester.h"
 #include "Corrade/Utility/AbstractHash.h"
 #include "Corrade/Utility/Debug.h"
+#include "Corrade/Utility/DebugStl.h"
 
 namespace Corrade { namespace Utility { namespace Test { namespace {
 

--- a/src/Corrade/Utility/Test/Sha1Test.cpp
+++ b/src/Corrade/Utility/Test/Sha1Test.cpp
@@ -41,6 +41,7 @@ struct Sha1Test: TestSuite::Tester {
     void exact64bytes();
     void exactOneBlockPadding();
     void twoBlockPadding();
+    void zeroInLeftover();
 
     void iterative();
     void reuse();
@@ -50,7 +51,8 @@ Sha1Test::Sha1Test() {
     addTests({&Sha1Test::emptyString,
               &Sha1Test::exact64bytes,
               &Sha1Test::exactOneBlockPadding,
-              &Sha1Test::twoBlockPadding});
+              &Sha1Test::twoBlockPadding,
+              &Sha1Test::zeroInLeftover});
 
     addRepeatedTests({&Sha1Test::iterative}, 128);
 
@@ -75,6 +77,15 @@ void Sha1Test::exactOneBlockPadding() {
 void Sha1Test::twoBlockPadding() {
     CORRADE_COMPARE(Sha1::digest("123456789a123456789b123456789c123456789d123456789e123456"),
                     Sha1::Digest::fromHexString("40e94c62ada5dc762f3e9c472001ca64a67d2cbb"));
+}
+
+void Sha1Test::zeroInLeftover() {
+    Sha1 sha;
+    sha << std::string(
+        "123456789a123456789b123456789c123456789d123456789e123456789f12341\000134", 69);
+    sha << std::string("\0001", 2);
+    CORRADE_COMPARE(sha.digest(),
+        Sha1::Digest::fromHexString("5fdc3d8c862c3c3f86735c536824aee668f89967"));
 }
 
 constexpr const char Data[] =

--- a/src/Corrade/Utility/Test/Sha1Test.py
+++ b/src/Corrade/Utility/Test/Sha1Test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import hashlib
+
+# Input data for every test case in Sha1Test.cpp
+inputs = {
+    "emptyString": [""],
+    "exact64bytes": [
+        "123456789a123456789b123456789c123456789d123456789e123456789f1234"],
+    "exactOneBlockPadding": [
+        "123456789a123456789b123456789c123456789d123456789e12345"],
+    "twoBlockPadding": [
+        "123456789a123456789b123456789c123456789d123456789e123456"],
+    "zeroInLeftover": [
+        "123456789a123456789b123456789c123456789d123456789e123456789f12341\000134",
+        "\0001"],
+    "noStringDelimiter" : [b"12345"]
+}
+
+# Print byte array data and length
+debug = False
+
+# Compute and print sha1 of test inputs
+for name in inputs:
+    data = inputs[name]
+    m = hashlib.sha1()
+    for d in data:
+        bytesArray = d if type(d) == bytes else d.encode()
+        m.update(bytesArray)
+        if debug:
+            print("data: {}\nlength:{}\n".format(bytesArray, len(bytesArray)))
+    print(name + ' = "' + m.hexdigest() + '"')


### PR DESCRIPTION
Hi @mosra !

As discussed via gitter, here is ArrayView input support for `Sha1 <<` and the removal of `DebugStl.h` from AbstractHash.

Cheers,
Jonathan