### PR TITLE
Utility::Debug: add std::ostream output operator call converter

### DIFF
--- a/doc/snippets/Utility.cpp
+++ b/doc/snippets/Utility.cpp
@@ -324,7 +324,7 @@ auto sendMessage = [](const std::string &) {};
 /* [Debug-ostream-delegation] */
 using Utility::OstreamDebug::operator<<;
 /// unfinished
-Containers::Array<float> array{Containers::InPlaceInit, { 0.1, 22.22, 3.14 }};
+Containers::Array<float> array{Containers::InPlaceInit, { 0.1f, 22.22f, 3.14f }};
 std::cout << "array = " << array << std::endl;
 
 std::ostringstream o;

--- a/doc/snippets/Utility.cpp
+++ b/doc/snippets/Utility.cpp
@@ -320,6 +320,21 @@ else
 }
 
 {
+auto sendMessage = [](const std::string &) {};
+/* [Debug-ostream-delegation] */
+using Utility::OstreamDebug::operator<<;
+/// unfinished
+Containers::Array<float> array{Containers::InPlaceInit, { 0.1, 22.22, 3.14 }};
+std::cout << "array = " << array << std::endl;
+
+std::ostringstream o;
+o << array << std::endl;
+sendMessage(o.str());
+/// unfinished
+/* [Debug-ostream-delegation] */
+}
+
+{
 /* [Debug-scoped-output] */
 std::ostringstream debugOut, errorOut;
 

--- a/src/Corrade/Utility/Debug.h
+++ b/src/Corrade/Utility/Debug.h
@@ -82,6 +82,13 @@ type using @ref Debug. Note that printing @ref std::vector or @ref std::map
 containers is already possible with the generic iterable container support in
 @ref Corrade/Utility/Debug.h.
 
+@subsection Utility-Debug-stl-ostream-delegation Ostream Delegation
+
+@ref Corrade/Utility/DebugStl.h also provides an @ref std::ostream @cpp
+operator<<() @ce for printing builtin types:
+
+@snippet Utility.cpp Debug-ostream-delegation
+
 @section Utility-Debug-scoped-output Scoped output redirection
 
 Output specified in class constructor is used for all instances created during

--- a/src/Corrade/Utility/Debug.h
+++ b/src/Corrade/Utility/Debug.h
@@ -89,6 +89,10 @@ operator<<() @ce for printing builtin types:
 
 @snippet Utility.cpp Debug-ostream-delegation
 
+It must be brought into the current namespace by a using declaration:
+
+@cpp using Corrade::Utility::OstreamDebug::operator<<; @ce
+
 @section Utility-Debug-scoped-output Scoped output redirection
 
 Output specified in class constructor is used for all instances created during

--- a/src/Corrade/Utility/DebugStl.h
+++ b/src/Corrade/Utility/DebugStl.h
@@ -147,8 +147,14 @@ struct DebugOstreamFallback {
 CORRADE_UTILITY_EXPORT Debug& operator<<(Debug& debug, Implementation::DebugOstreamFallback&& value);
 #endif
 
-}}
+namespace OstreamDebug {
 
+/**
+@brief Print a builtin type to an ostream
+
+Allows calls like @cpp std::cout << Magnum::Vector2{0.2, 3.14}; @ce to be
+delegated to a @ref Debug object. Creates a @ref Debug object on every call.
+*/
 template<typename T>
 typename std::enable_if<
     Corrade::Utility::Implementation::HasDebugStreamOperator<T>::value && !Corrade::Utility::Implementation::HasOstreamOperator<T>::value,
@@ -158,5 +164,9 @@ typename std::enable_if<
   debug << val;
   return os;
 }
+
+}
+
+}}
 
 #endif

--- a/src/Corrade/Utility/DebugStl.h
+++ b/src/Corrade/Utility/DebugStl.h
@@ -111,11 +111,19 @@ CORRADE_HAS_TYPE(
     >::value>::type
 );
 
+CORRADE_HAS_TYPE(
+    HasDebugStreamOperator,
+    typename std::enable_if<std::is_same<
+        decltype(DeclareLvalueReference<Debug>() << std::declval<T>()),
+        std::add_lvalue_reference<Debug>::type
+    >::value>::type
+);
+
 /* Used by Debug::operator<<(Implementation::DebugOstreamFallback&&) */
 struct DebugOstreamFallback {
     template<
         class T,
-        typename = typename std::enable_if<HasOstreamOperator<T>::value>::type
+        typename = typename std::enable_if<HasOstreamOperator<T>::value && !HasDebugStreamOperator<T>::value>::type
     > /*implicit*/ DebugOstreamFallback(const T& t): applier(&DebugOstreamFallback::applyImpl<T>), value(&t) {}
 
     void apply(std::ostream& s) const {

--- a/src/Corrade/Utility/DebugStl.h
+++ b/src/Corrade/Utility/DebugStl.h
@@ -149,4 +149,14 @@ CORRADE_UTILITY_EXPORT Debug& operator<<(Debug& debug, Implementation::DebugOstr
 
 }}
 
+template<typename T>
+typename std::enable_if<
+    Corrade::Utility::Implementation::HasDebugStreamOperator<T>::value && !Corrade::Utility::Implementation::HasOstreamOperator<T>::value,
+    std::ostream
+>::type &operator<<(std::ostream &os, const T &val) {
+  Corrade::Utility::Debug debug{&os, Corrade::Utility::Debug::Flag::NoNewlineAtTheEnd};
+  debug << val;
+  return os;
+}
+
 #endif

--- a/src/Corrade/Utility/DebugStl.h
+++ b/src/Corrade/Utility/DebugStl.h
@@ -103,9 +103,32 @@ template<class ...Args> Debug& operator<<(Debug& debug, const std::tuple<Args...
 
 namespace Implementation {
 
+template<typename T>
+typename std::add_lvalue_reference<T>::type declare_lvalue_reference() noexcept;
+
+template<typename T>
+struct has_ostream_operator {
+    private:
+        template<typename C>
+        static constexpr auto check(C *) ->
+        typename std::is_same<
+            decltype(declare_lvalue_reference<std::ostream>() << std::declval<C>()),
+            std::add_lvalue_reference<std::ostream>::type
+        >::type;
+
+        template<typename>
+        static constexpr std::false_type check(...);
+
+    public:
+        static constexpr bool value = decltype(check<T>(nullptr))::value;
+};
+
 /* Used by Debug::operator<<(Implementation::DebugOstreamFallback&&) */
 struct DebugOstreamFallback {
-    template<class T> /*implicit*/ DebugOstreamFallback(const T& t): applier(&DebugOstreamFallback::applyImpl<T>), value(&t) {}
+    template<
+        class T,
+        typename = typename std::enable_if<has_ostream_operator<T>::value>::type
+    > /*implicit*/ DebugOstreamFallback(const T& t): applier(&DebugOstreamFallback::applyImpl<T>), value(&t) {}
 
     void apply(std::ostream& s) const {
         (this->*applier)(s);

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -880,10 +880,11 @@ void DebugTest::ostreamDelegationPriority() {
 }
 
 void DebugTest::ostreamDelegationPriorityImplicitConversion() {
+    using OstreamDebug::operator<<;
     Containers::Array<int> array{Containers::InPlaceInit, { 1, 2, 3 }};
     std::ostringstream out;
     out << array;
-    CORRADE_COMPARE(out.str(), "{ 1, 2, 3 }");
+    CORRADE_COMPARE(out.str(), "{1, 2, 3}");
 }
 
 void DebugTest::scopedOutput() {
@@ -1022,9 +1023,9 @@ void DebugTest::sourceLocation() {
 
     #ifdef CORRADE_UTILITY_DEBUG_HAS_SOURCE_LOCATION
     CORRADE_COMPARE(out.str(),
-        __FILE__ ":1014: hello\n"
-        __FILE__ ":1016: and this is from another line\n"
-        __FILE__ ":1018\n"
+        __FILE__ ":1015: hello\n"
+        __FILE__ ":1017: and this is from another line\n"
+        __FILE__ ":1019\n"
         "this no longer\n");
     #else
     CORRADE_COMPARE(out.str(),

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -81,7 +81,7 @@ struct DebugTest: TestSuite::Tester {
 
     void ostreamFallback();
     void ostreamFallbackPriority();
-    
+
     void ostreamDelegationInternalUsing();
     void ostreamDelegationExternalUsing();
     void ostreamDelegationCyclicDependency();
@@ -156,7 +156,7 @@ DebugTest::DebugTest() {
 
         &DebugTest::ostreamFallback,
         &DebugTest::ostreamFallbackPriority,
-        
+
         &DebugTest::ostreamDelegationInternalUsing,
         &DebugTest::ostreamDelegationExternalUsing,
         &DebugTest::ostreamDelegationCyclicDependency,
@@ -856,7 +856,7 @@ namespace OstreamDelegationNamespace1 {
     inline Debug& operator<<(Debug& debug, const Grault& val) {
         return debug << val.i << "grault from Debug";
     }
-    
+
     using OstreamDebug::operator<<;
 }
 

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -869,8 +869,8 @@ void DebugTest::ostreamDelegationExternalUsing() {
 struct ClassWithoutStreamOperator {};
 
 void DebugTest::ostreamDelegationCyclicDependency() {
-    CORRADE_VERIFY(!Implementation::HasOstreamOperator<ClassWithoutStreamOperator>::value);
-    CORRADE_VERIFY(!Implementation::HasDebugStreamOperator<ClassWithoutStreamOperator>::value);
+    CORRADE_VERIFY(!Implementation::HasBestFittingOstreamOperator<ClassWithoutStreamOperator>::value);
+    CORRADE_VERIFY(!Implementation::HasBestFittingDebugOperator<ClassWithoutStreamOperator>::value);
 }
 
 void DebugTest::ostreamDelegationPriority() {

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -31,7 +31,7 @@
 #include <vector>
 
 #include "Corrade/TestSuite/Tester.h"
-#include "Corrade/Utility/Debug.h"
+#include "Corrade/Containers/Array.h"
 #include "Corrade/Utility/DebugStl.h"
 
 #ifndef CORRADE_TARGET_EMSCRIPTEN
@@ -81,6 +81,12 @@ struct DebugTest: TestSuite::Tester {
 
     void ostreamFallback();
     void ostreamFallbackPriority();
+    
+    void ostreamDelegationInternalUsing();
+    void ostreamDelegationExternalUsing();
+    void ostreamDelegationCyclicDependency();
+    void ostreamDelegationPriority();
+    void ostreamDelegationPriorityImplicitConversion();
 
     void scopedOutput();
 
@@ -150,6 +156,12 @@ DebugTest::DebugTest() {
 
         &DebugTest::ostreamFallback,
         &DebugTest::ostreamFallbackPriority,
+        
+        &DebugTest::ostreamDelegationInternalUsing,
+        &DebugTest::ostreamDelegationExternalUsing,
+        &DebugTest::ostreamDelegationCyclicDependency,
+        &DebugTest::ostreamDelegationPriority,
+        &DebugTest::ostreamDelegationPriorityImplicitConversion,
 
         &DebugTest::scopedOutput,
 
@@ -817,6 +829,61 @@ void DebugTest::ostreamFallbackPriority() {
     std::ostringstream out;
     Debug(&out) << Baz{};
     CORRADE_COMPARE(out.str(), "baz from Debug\n");
+}
+
+namespace OstreamDelegationNamespace0 {
+    struct Corge {
+      int i;
+    };
+
+    inline Debug& operator<<(Debug& debug, const Corge& val) {
+        return debug << val.i << "corge from Debug";
+    }
+}
+
+void DebugTest::ostreamDelegationInternalUsing() {
+    using OstreamDebug::operator<<;
+    std::ostringstream out;
+    out << OstreamDelegationNamespace0::Corge{42};
+    CORRADE_COMPARE(out.str(), "42 corge from Debug");
+}
+
+namespace OstreamDelegationNamespace1 {
+    struct Grault {
+      int i;
+    };
+
+    inline Debug& operator<<(Debug& debug, const Grault& val) {
+        return debug << val.i << "grault from Debug";
+    }
+    
+    using OstreamDebug::operator<<;
+}
+
+void DebugTest::ostreamDelegationExternalUsing() {
+    std::ostringstream out;
+    out << OstreamDelegationNamespace1::Grault{36};
+    CORRADE_COMPARE(out.str(), "36 grault from Debug");
+}
+
+struct ClassWithoutStreamOperator {};
+
+void DebugTest::ostreamDelegationCyclicDependency() {
+    CORRADE_VERIFY(!Implementation::HasOstreamOperator<ClassWithoutStreamOperator>::value);
+    CORRADE_VERIFY(!Implementation::HasDebugStreamOperator<ClassWithoutStreamOperator>::value);
+}
+
+void DebugTest::ostreamDelegationPriority() {
+    std::ostringstream out;
+    out << Baz{};
+    CORRADE_COMPARE(out.str(), "baz from ostream");
+}
+
+void DebugTest::ostreamDelegationPriorityImplicitConversion() {
+    Containers::Array<int> array{Containers::InPlaceInit, { 1, 2, 3 }};
+    std::ostringstream out;
+    out << array;
+    CORRADE_COMPARE(out.str(), "{ 1, 2, 3 }");
 }
 
 void DebugTest::scopedOutput() {

--- a/src/Corrade/Utility/Test/DebugTest.cpp
+++ b/src/Corrade/Utility/Test/DebugTest.cpp
@@ -1022,9 +1022,9 @@ void DebugTest::sourceLocation() {
 
     #ifdef CORRADE_UTILITY_DEBUG_HAS_SOURCE_LOCATION
     CORRADE_COMPARE(out.str(),
-        __FILE__ ":947: hello\n"
-        __FILE__ ":949: and this is from another line\n"
-        __FILE__ ":951\n"
+        __FILE__ ":1014: hello\n"
+        __FILE__ ":1016: and this is from another line\n"
+        __FILE__ ":1018\n"
         "this no longer\n");
     #else
     CORRADE_COMPARE(out.str(),

--- a/src/Corrade/Utility/TypeTraits.h
+++ b/src/Corrade/Utility/TypeTraits.h
@@ -164,7 +164,7 @@ template<class T> using IsStringLike = std::integral_constant<bool,
 }}
 
 /**
-@brief Like @cpp std::declval @ce, but declares an lvalue refrence
+@brief Like @cpp std::declval @ce, but declares an lvalue reference
 */
 template<typename T>
 typename std::add_lvalue_reference<T>::type DeclareLvalueReference() noexcept;

--- a/src/Corrade/Utility/TypeTraits.h
+++ b/src/Corrade/Utility/TypeTraits.h
@@ -163,9 +163,4 @@ template<class T> using IsStringLike = std::integral_constant<bool,
 
 }}
 
-/**
-@brief Like @cpp std::declval @ce, but declares an lvalue reference
-*/
-template<typename T> typename std::add_lvalue_reference<T>::type DeclareLvalueReference() noexcept;
-
 #endif

--- a/src/Corrade/Utility/TypeTraits.h
+++ b/src/Corrade/Utility/TypeTraits.h
@@ -163,4 +163,10 @@ template<class T> using IsStringLike = std::integral_constant<bool,
 
 }}
 
+/**
+@brief Like @cpp std::declval @ce, but declares an lvalue refrence
+*/
+template<typename T>
+typename std::add_lvalue_reference<T>::type DeclareLvalueReference() noexcept;
+
 #endif

--- a/src/Corrade/Utility/TypeTraits.h
+++ b/src/Corrade/Utility/TypeTraits.h
@@ -166,7 +166,6 @@ template<class T> using IsStringLike = std::integral_constant<bool,
 /**
 @brief Like @cpp std::declval @ce, but declares an lvalue reference
 */
-template<typename T>
-typename std::add_lvalue_reference<T>::type DeclareLvalueReference() noexcept;
+template<typename T> typename std::add_lvalue_reference<T>::type DeclareLvalueReference() noexcept;
 
 #endif


### PR DESCRIPTION
Compile errors are much clearer for types without a stream operator, and avoids being an actual catch-all.

This is a bit of a selfish pr, as my code to translate `Debug` `operator<<`s to `std::ostream` `operator<<`s is bugged when there is a catchall for Debug stream `operator<<`s.
Both stream fallbacks use each other. This results in being able to compile `cout << UnprintableClass{}`.
At runtime it gets stuck in recursion, flipflopping between both `operator<<`s. I thought that was pretty interesting.

Please tell me if I made any formatting mistakes.