### PR TITLE
Utility: improve String::split by replacing copy with move

### DIFF
--- a/src/Corrade/Utility/String.cpp
+++ b/src/Corrade/Utility/String.cpp
@@ -69,13 +69,13 @@ std::vector<std::string> splitWithoutEmptyParts(const std::string& string, const
 
     while((pos = string.find_first_of(delimiters, oldpos, delimiters.size())) != std::string::npos) {
         if(pos != oldpos)
-            parts.push_back(string.substr(oldpos, pos-oldpos));
+            parts.emplace_back(std::move(string.substr(oldpos, pos-oldpos)));
 
         oldpos = pos+1;
     }
 
     if(!string.empty() && (oldpos < string.size()))
-        parts.push_back(string.substr(oldpos));
+        parts.emplace_back(std::move(string.substr(oldpos)));
 
     return parts;
 }
@@ -190,12 +190,12 @@ std::vector<std::string> split(const std::string& string, const char delimiter) 
     std::size_t oldpos = 0, pos = std::string::npos;
 
     while((pos = string.find(delimiter, oldpos)) != std::string::npos) {
-        parts.push_back(string.substr(oldpos, pos-oldpos));
+        parts.emplace_back(std::move(string.substr(oldpos, pos-oldpos)));
         oldpos = pos+1;
     }
 
     if(!string.empty())
-        parts.push_back(string.substr(oldpos));
+        parts.emplace_back(std::move(string.substr(oldpos)));
 
     return parts;
 }
@@ -206,13 +206,13 @@ std::vector<std::string> splitWithoutEmptyParts(const std::string& string, const
 
     while((pos = string.find(delimiter, oldpos)) != std::string::npos) {
         if(pos != oldpos)
-            parts.push_back(string.substr(oldpos, pos-oldpos));
+            parts.emplace_back(std::move(string.substr(oldpos, pos-oldpos)));
 
         oldpos = pos+1;
     }
 
     if(!string.empty() && (oldpos < string.size()))
-        parts.push_back(string.substr(oldpos));
+        parts.emplace_back(std::move(string.substr(oldpos)));
 
     return parts;
 }


### PR DESCRIPTION
Avoid some unnecessary string copyings then a little [benchmark](https://github.com/linuxaged/string-benchmark/blob/master/main.cpp):

```
01/26/20 15:55:40
Running C:\workspace\string-benchmark\build\Release\main.exe
Run on (8 X 4008 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 8388K (x1)
----------------------------------------------------------
Benchmark                Time             CPU   Iterations
----------------------------------------------------------
BM_absl                449 ns          449 ns      1600000
BM_boost              1062 ns         1032 ns       560000
BM_corrade             669 ns          670 ns      1120000
BM_corrade_move        710 ns          711 ns       746667
```