### PR TITLE
Directory: Print an error when mkpath() returns false

### DIFF
--- a/src/Corrade/Utility/CMakeLists.txt
+++ b/src/Corrade/Utility/CMakeLists.txt
@@ -104,6 +104,12 @@ if(WITH_UTILITY)
         list(APPEND CorradeUtility_PRIVATE_HEADERS Implementation/WindowsWeakSymbol.h)
     endif()
 
+    # Functionality specific to Windows builds
+    if(CORRADE_TARGET_WINDOWS)
+        list(APPEND CorradeUtility_SRCS Implementation/WindowsError.cpp)
+        list(APPEND CorradeUtility_PRIVATE_HEADERS Implementation/WindowsError.h)
+    endif()
+
     # Objects shared between main and test library
     add_library(CorradeUtilityObjects OBJECT
         ${CorradeUtility_SRCS}
@@ -194,8 +200,10 @@ if(NOT CMAKE_CROSSCOMPILING)
         Resource.cpp
         String.cpp)
     if(CORRADE_TARGET_WINDOWS)
-        # Needed for dealing with the design failure that's called "Unicode WINAPI"
-        list(APPEND CorradeUtilityRc_SRCS Unicode.cpp)
+        list(APPEND CorradeUtilityRc_SRCS
+            # Needed for dealing with the design failure that's called "Unicode WINAPI"
+            Unicode.cpp
+            Implementation/WindowsError.cpp)
 
         # Functionality specific to static Windows builds. Not really needed
         # for corrade-rc as it doesn't load any plugins yet but easier than

--- a/src/Corrade/Utility/Directory.cpp
+++ b/src/Corrade/Utility/Directory.cpp
@@ -437,8 +437,8 @@ std::string libraryLocation(const void* address) {
     #elif defined(CORRADE_TARGET_WINDOWS) && !defined(CORRADE_TARGET_WINDOWS_RT)
     HMODULE module{};
     if(!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, reinterpret_cast<const char*>(address), &module)) {
-        /** @todo use FormatMessage() for a string error */
-        Error{} << "Utility::Directory::libraryLocation(): can't get library location:" << GetLastError();
+        Error{} << "Utility::Directory::libraryLocation(): can't get library location:"
+            << Utility::Implementation::windowsErrorString(GetLastError());
         return {};
     }
 

--- a/src/Corrade/Utility/Implementation/WindowsError.cpp
+++ b/src/Corrade/Utility/Implementation/WindowsError.cpp
@@ -1,0 +1,56 @@
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2020 Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+#include "WindowsError.h"
+
+#include <string>
+#include "Corrade/Utility/Unicode.h"
+#include "Corrade/Containers/ScopeGuard.h"
+
+#define WIN32_LEAN_AND_MEAN 1
+#define VC_EXTRALEAN
+#include <windows.h>
+
+namespace Corrade { namespace Utility { namespace Implementation {
+
+std::string windowsErrorString(unsigned int errorCode) {
+    WCHAR* errorStringW = nullptr;
+    FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_ALLOCATE_BUFFER,
+        nullptr, errorCode, 0, reinterpret_cast<LPWSTR>(&errorStringW),
+        0, nullptr);
+    Containers::ScopeGuard e{errorStringW,
+        #ifdef CORRADE_MSVC2015_COMPATIBILITY
+        /* MSVC 2015 is unable to cast the parameter for LocalFree */
+        [](WCHAR* p){ LocalFree(p); }
+        #else
+        LocalFree
+        #endif
+    };
+    /* Convert to UTF-8 and cut off final newline that FormatMessages adds */
+    return Unicode::narrow(Containers::arrayView<const wchar_t>(errorStringW,
+        wcslen(errorStringW)).except(1));
+}
+
+}}}

--- a/src/Corrade/Utility/Implementation/WindowsError.h
+++ b/src/Corrade/Utility/Implementation/WindowsError.h
@@ -1,0 +1,43 @@
+#ifndef Corrade_Utility_Implementation_WindowsError_h
+#define Corrade_Utility_Implementation_WindowsError_h
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019 Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2020 Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Corrade/configure.h"
+
+#include "Corrade/Utility/StlForwardString.h"
+
+#ifndef CORRADE_TARGET_WINDOWS
+#error this file is only meant to be used in Windows builds
+#endif
+
+namespace Corrade { namespace Utility { namespace Implementation {
+
+std::string windowsErrorString(unsigned int errorCode);
+
+}}}
+
+#endif

--- a/src/Corrade/Utility/Test/DirectoryTest.cpp
+++ b/src/Corrade/Utility/Test/DirectoryTest.cpp
@@ -1065,7 +1065,7 @@ void DirectoryTest::fileSizeEarlyEof() {
     #ifdef __linux__
     constexpr const char* file = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor";
     if(!Directory::exists(file))
-        CORRADE_SKIP(file + std::string{"doesn't exist, can't test"});
+        CORRADE_SKIP(file + std::string{" doesn't exist, can't test"});
     Containers::Optional<std::size_t> size = Directory::fileSize(file);
     CORRADE_VERIFY(size);
     CORRADE_COMPARE_AS(*size, Directory::read(file).size(),


### PR DESCRIPTION
Hi @mosra,

as discussed per gitter, here's the PR that adds some error messages to failures in `Directory::mkpath()`.

Cheers,
Jonathan