### PR TITLE
[MinGW/Clang] Fix SEGFAULTs when logging to globals

### DIFF
--- a/src/Corrade/Utility/Debug.cpp
+++ b/src/Corrade/Utility/Debug.cpp
@@ -117,7 +117,7 @@ CORRADE_VISIBILITY_EXPORT
     #endif
 #endif
 DebugGlobals debugGlobals{
-    &std::cout, &std::cerr, &std::cerr,
+    Debug::defaultOutput(), Warning::defaultOutput(), Error::defaultOutput(),
     #if !defined(CORRADE_TARGET_WINDOWS) ||defined(CORRADE_UTILITY_USE_ANSI_COLORS)
     Debug::Color::Default, false
     #endif

--- a/src/Corrade/Utility/Debug.cpp
+++ b/src/Corrade/Utility/Debug.cpp
@@ -117,7 +117,12 @@ CORRADE_VISIBILITY_EXPORT
     #endif
 #endif
 DebugGlobals debugGlobals{
+    #if defined(CORRADE_TARGET_MINGW) && defined(CORRADE_TARGET_CLANG)
+    /* Referencing the globals directly makes MinGW Clang segfault for some reason */
     Debug::defaultOutput(), Warning::defaultOutput(), Error::defaultOutput(),
+    #else
+    &std::cout, &std::cerr, &std::cerr,
+    #endif
     #if !defined(CORRADE_TARGET_WINDOWS) ||defined(CORRADE_UTILITY_USE_ANSI_COLORS)
     Debug::Color::Default, false
     #endif


### PR DESCRIPTION
Okay, I think I found the issue with https://github.com/mosra/magnum/pull/417.

Changing few lines in `src/Corrade/Utility/Debug.cpp` allowed me to boot up a sample projet using a Magnum Clang build. 

My 2cts guess here is that Clang does some optimizations and "hard stores" pointer addresses of the standard outputs when directly referenced "as it", references that may change outside of Corrade, resulting in SEGFAULTs when Magnum tries to use its logging capabilities.