### PR TITLE
Directory: Close a leaking handle in list() and test

### DIFF
--- a/src/Corrade/Utility/Directory.cpp
+++ b/src/Corrade/Utility/Directory.cpp
@@ -628,6 +628,7 @@ std::vector<std::string> list(const std::string& path, Flags flags) {
     WIN32_FIND_DATAW data;
     HANDLE hFile = FindFirstFileW(widen(join(path, "*")).data(), &data);
     if(hFile == INVALID_HANDLE_VALUE) return list;
+    Containers::ScopeGuard exit{hFile, FindClose};
 
     /* Explicitly add `.` for compatibility with other systems */
     if(!(flags & (Flag::SkipDotAndDotDot|Flag::SkipDirectories))) list.push_back(".");

--- a/src/Corrade/Utility/Test/DirectoryTest.cpp
+++ b/src/Corrade/Utility/Test/DirectoryTest.cpp
@@ -40,6 +40,10 @@
 
 #include <clocale>
 
+#ifdef CORRADE_TARGET_WINDOWS
+#include <windows.h>
+#endif
+
 #include "configure.h"
 
 #ifdef CORRADE_UTILITY_LINUX
@@ -933,9 +937,22 @@ void DirectoryTest::list() {
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
+    #ifdef CORRADE_TARGET_WINDOWS
+    DWORD handleCount = 0;
+    GetProcessHandleCount(GetCurrentProcess(), &handleCount);
+    #endif
+
     CORRADE_COMPARE_AS(Directory::list(_testDir),
         (std::vector<std::string>{".", "..", "dir", "file"}),
         TestSuite::Compare::SortedContainer);
+
+    #ifdef CORRADE_TARGET_WINDOWS
+    /* Ensure we are not leaking handles */
+    DWORD newHandleCount = 0;
+    GetProcessHandleCount(GetCurrentProcess(), &newHandleCount);
+
+    CORRADE_COMPARE(newHandleCount, handleCount);
+    #endif
 }
 
 void DirectoryTest::listSkipDirectories() {


### PR DESCRIPTION
Hi @mosra !

As per gitter, here's the fix for the leaking handle. Windows will refuse to delete folders with open handles, which means every `list()`-ed folder would be locked until application exit.

Best,
Jonathan