### PR TITLE
String: Fix "Use of memory after it is freed" when assigning to self

### DIFF
--- a/src/Corrade/Containers/String.cpp
+++ b/src/Corrade/Containers/String.cpp
@@ -189,6 +189,8 @@ String::String(String&& other) noexcept {
 }
 
 String& String::operator=(const String& other) {
+    if(other == *this) return *this;
+
     destruct();
 
     const std::pair<const char*, std::size_t> data = other.dataInternal();


### PR DESCRIPTION
`destruct()` can call `delete[]`, but then we use the memory in `operator=`.

Found using clang static analysis.