### PR TITLE
Set Corrade::rc as GLOBAL when cross-compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ if(CMAKE_CROSSCOMPILING)
     if(NOT CORRADE_RC_EXECUTABLE)
         message(FATAL_ERROR "Native `corrade-rc` executable, which is needed when crosscompiling, was not found")
     endif()
-    add_executable(Corrade::rc IMPORTED)
+    add_executable(Corrade::rc IMPORTED GLOBAL)
     set_property(TARGET Corrade::rc PROPERTY IMPORTED_LOCATION ${CORRADE_RC_EXECUTABLE})
 endif()
 


### PR DESCRIPTION
`corrade_add_resource` seems unable to find `corrade-rc` unless I set the imported target as `GLOBAL`. 

![image](https://user-images.githubusercontent.com/13903151/97145847-2719ba80-1767-11eb-87a1-5f914b884621.png)

This change is quite harmless IMO, but maybe we should add a comment to justify it ?

Cheers !