### PR TITLE
Utility: use Emscripten's _malloc instead of internal allocate

### DIFF
--- a/src/Corrade/Utility/Test/ArgumentsTest.cpp
+++ b/src/Corrade/Utility/Test/ArgumentsTest.cpp
@@ -842,7 +842,7 @@ void ArgumentsTest::parseEnvironment() {
     CORRADE_SKIP("No environment on this platform.");
     #else
     if(!hasEnv("ARGUMENTSTEST_SIZE") || !hasEnv("ARGUMENTSTEST_VERBOSE") || !hasEnv("ARGUMENTSTEST_COLOR"))
-        CORRADE_SKIP("Environment not set. Call the test with ARGUMENTSTEST_SIZE=1337 ARGUMENTSTEST_VERBOSE=ON ARGUMENTTEST_COLOR=OFF to enable this test case.");
+        CORRADE_SKIP("Environment not set. Call the test with ARGUMENTSTEST_SIZE=1337 ARGUMENTSTEST_VERBOSE=ON ARGUMENTSTEST_COLOR=OFF to enable this test case.");
 
     Arguments args;
     args.addOption("size").setFromEnvironment("size", "ARGUMENTSTEST_SIZE")


### PR DESCRIPTION
See https://github.com/mosra/magnum/pull/483 for background discussion.

I compiled with `CMAKE_EXE_LINKER_FLAGS_RELEASE=-s ASSERTIONS=2` but couldn't get the old code to fire an assertion, I might have set the wrong CMake flag?

Utility::ArgumentsTest output:

> OK [01] environment()
> OK [02] environmentUtf8()
> OK [03] copy()
> OK [04] move()
> OK [05] helpArgumentsOnly()
> OK [06] helpNamedOnly()
> OK [07] helpBoth()
> OK [08] helpText()
> OK [09] helpEmpty()
> OK [10] helpEnvironment()
> OK [11] helpEnvironmentPrefixed()
> OK [12] helpAfterParse()
> OK [13] helpLongKeys()
> OK [14] helpLongKeyNotPrinted()
> OK [15] helpFinalOptionalArgument()
> OK [16] helpFinalOptionalArgumentDefaultValueOnly()
> OK [17] setHelpNotFound()
> OK [18] setHelpKeyForBoolean()
> OK [19] duplicateKey()
> OK [20] duplicateShortKey()
> OK [21] emptyKey()
> OK [22] disallowedCharacter()
> OK [23] disallowedCharacterShort()
> OK [24] disallowedIgnoreUnknown()
> OK [25] arrayArgumentTwice()
> OK [26] finalOptionalArgumentTwice()
> OK [27] finalOptionalArgumentWithArray()
> OK [28] argumentAfterFinalOptionalArgument()
> OK [29] arrayArgumentAfterFinalOptionalArgument()
> OK [30] parseNullptr()
> Superfluous command-line argument error
> OK [31] parseHelp()
> OK [32] parseArguments()
> OK [33] parseMixed()
> OK [34] parseStringView()
> OK [35] parseCustomType()
> OK [36] parseCustomTypeFlags()
> OK [37] parseCustomTypeUsingContainersString()
> OK [38] parseEnvironment()
> OK [39] parseEnvironmentUtf8()
> OK [40] parseFinalOptionalArgument()
> OK [41] parseFinalOptionalArgumentDefault()
> OK [42] parseShortOptionValuePack()
> OK [43] parseShortOptionValuePackEmpty()
> OK [44] parseShortBooleanOptionPack()
> OK [45] parseShortBooleanOptionValuePack()
> OK [46] parseArrayArguments()
> OK [47] parseArrayOptions()
> OK [48] parseUnknownArgument()
> OK [49] parseUnknownShortArgument()
> OK [50] parseSuperfluousArgument()
> OK [51] parseSingleDash()
> OK [52] parseArgumentAfterSeparator()
> OK [53] parseInvalidShortArgument()
> OK [54] parseInvalidLongArgument()
> OK [55] parseInvalidLongArgumentDashes()
> OK [56] parseMissingValue()
> OK [57] parseMissingOption()
> OK [58] parseMissingArgument()
> OK [59] parseMissingArrayArgumentMiddle()
> OK [60] parseMissingArrayArgumentLast()
> OK [61] prefixedParse()
> OK [62] prefixedParseMinus()
> OK [63] prefixedParseMinusMinus()
> OK [64] prefixedParseHelpArgument()
> OK [65] prefixedHelpWithoutPrefix()
> OK [66] prefixedHelpWithPrefix()
> OK [67] prefixedHelpLongPrefix()
> OK [68] prefixedDisallowedCalls()
> OK [69] prefixedDisallowedWithPrefix()
> OK [70] prefixedDisallowedWithPrefixAfterSkipPrefix()
> OK [71] prefixedUnknownWithPrefix()
> OK [72] prefixedInvalidPrefixedName()
> OK [73] prefixedInvalidUnprefixedName()
> OK [74] prefixedIgnoreUnknown()
> OK [75] prefixedIgnoreUnknownInvalidPrefixedName()
> OK [76] notParsedYet()
> OK [77] notParsedYetOnlyHelp()
> OK [78] valueNotFound()
> OK [79] valueMismatchedUse()
> OK [80] arrayValueOutOfBounds()
> OK [81] parseErrorCallback()
> OK [82] parseErrorCallbackIgnoreAll()
> OK [83] parseErrorCallbackIgnoreAll2()
> OK [84] debugParseError()
> Finished Corrade::Utility::Test::ArgumentsTest with 0 errors out of 240 checks.