### PR TITLE
Fix typo in Containers::arraySize doc snippet

### DIFF
--- a/doc/snippets/Containers.cpp
+++ b/doc/snippets/Containers.cpp
@@ -494,7 +494,7 @@ static_cast<void>(b);
 /* [arraySize] */
 int data[15];
 
-std::size_t size = Containers::arraySize(data); // size == 5
+std::size_t size = Containers::arraySize(data); // size == 15
 /* [arraySize] */
 static_cast<void>(size);
 }


### PR DESCRIPTION
I have to admit I still have the tiniest bit of fear that this is some arithmetic going over my head