### PR TITLE
Containers: make non-SSO String layout match StringView layout

### DIFF
--- a/src/Corrade/Containers/String.h
+++ b/src/Corrade/Containers/String.h
@@ -1106,7 +1106,7 @@ class CORRADE_UTILITY_EXPORT String {
                                 | LSB |||||||   MSB   |
             +---------+---------+-----+++++++---------+
             |  data   |  data   |      size      | 00 |
-            | pointer | deleter |                |    |
+            | deleter | pointer |                |    |
             |  8B/4B  |  8B/4B  |  56b/24b  | 6b | 2b |
             +---------+---------+-----------+---------+
 
@@ -1141,14 +1141,16 @@ class CORRADE_UTILITY_EXPORT String {
             std::uint8_t size;
             #endif
         };
+        /* At offset of 0 on BE and sizeof(void*) on LE the layout is
+           compatible with StringView */
         struct Large {
             #ifdef CORRADE_TARGET_BIG_ENDIAN
             std::size_t size;
             char* data;
             void(*deleter)(char*, std::size_t);
             #else
-            char* data;
             void(*deleter)(char*, std::size_t);
+            char* data;
             std::size_t size;
             #endif
         };


### PR DESCRIPTION
Original idea by @williamjcm. Might theoretically be useful for taking an `Array<String>` and turning it into a `StridedArrayView1D<StringView>` without having to allocate a temporary copy. However:

 - the ifdefs for BE will likely become a maintenance nightmare over time (unless BE support gets dropped)
 - since it can't work for SSO strings, benefits are questionable ("let's save an allocation of a large temporary array by making several small allocations to de-SSO the strings first")
 - and it would mean any APIs taking `ArrayView<StringView>` now have to take a `StridedArrayView` as well ... imagine the pain with ambiguous overloads

TODO:

- [ ] also now that we're so close it might make sense to have the unused bit in String size be always 1, matching the `NullTerminated` flag of `StringView`? But then every size retrieval gets "a bit" more complicated again.

Counterpoints:

- It might be useful to reuse the unused bit in String for a `Global` flag, instead of `NullTerminated`, to make it possible to restore a global `StringView` out of a `String::nullTerminatedGlobalView()`
- Delegation from a String to StringView APIs is currently done as `StringView{*this}.foo(bar, baz)`. This would make it possible to just do an ugly reinterpret cast instead (thus zero-cost), but only for non-SSO strings. Which isn't really helpful.

Putting this aside until I'm clearer on whether this has any practical use despite all the disadvantages.