### PR TITLE
Gather resource dependencies by executing corrade-rc instead of a nasty CMake regex

### DIFF
--- a/modules/UseCorrade.cmake
+++ b/modules/UseCorrade.cmake
@@ -506,19 +506,17 @@ function(corrade_add_resource name configurationFile)
         message(FATAL_ERROR "The Corrade::rc target, needed by corrade_add_resource() and corrade_add_static_plugin(), doesn't exist. Add the Utility / rc component to your find_package() or enable WITH_UTILITY / WITH_RC if you have Corrade as a CMake subproject.")
     endif()
 
-    # Parse dependencies from the file
-    set(dependencies )
-    set(filenameRegex "^[ \t]*filename[ \t]*=[ \t]*\"?([^\"]+)\"?[ \t]*$")
-    get_filename_component(configurationFilePath ${configurationFile} PATH)
-
-    file(STRINGS "${configurationFile}" files REGEX ${filenameRegex} ENCODING UTF-8)
-    foreach(file ${files})
-        string(REGEX REPLACE ${filenameRegex} "\\1" filename "${file}")
-        if(NOT IS_ABSOLUTE "${filename}" AND configurationFilePath)
-            set(filename "${configurationFilePath}/${filename}")
-        endif()
-        list(APPEND dependencies "${filename}")
-    endforeach()
+    # Get dependency information for proper incremental rebuilds
+    execute_process(
+        # TODO yeah can't use a target name here, and of course what would this
+        #   do if the corrade-rc binary isn't even built yet?!
+        COMMAND Corrade::rc ${name} --dependencies ${configurationFile}
+        RESULT_VARIABLE dependencies
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    message(STATUS "eyy" ${dependencies})
+    # In the unlikely case where there would be ; in the filenames themselves
+    string(REGEX REPLACE ";" "\\\\;" dependencies "${dependencies}")
+    string(REGEX REPLACE "\n" ";" dependencies "${dependencies}")
 
     # Force IDEs display also the resource files in project view
     add_custom_target(${name}-dependencies SOURCES ${dependencies})

--- a/src/Corrade/Utility/CMakeLists.txt
+++ b/src/Corrade/Utility/CMakeLists.txt
@@ -212,6 +212,7 @@ if(NOT CMAKE_CROSSCOMPILING)
         Debug.cpp
         Configuration.cpp
         ConfigurationGroup.cpp
+        ConfigurationValue.cpp
         Format.cpp
         Path.cpp
         String.cpp

--- a/src/Corrade/Utility/Test/ResourceCompileTest.cpp
+++ b/src/Corrade/Utility/Test/ResourceCompileTest.cpp
@@ -116,6 +116,13 @@ void ResourceCompileTest::compileFrom() {
     CORRADE_COMPARE_AS(Implementation::resourceCompileFrom("ResourceTestData", conf),
         Path::join(RESOURCE_TEST_DIR, "compiled.cpp"),
         TestSuite::Compare::StringToFile);
+
+    Containers::Optional<Containers::Array<Containers::String>> dependencies = Implementation::resourceDependencies(conf);
+    CORRADE_VERIFY(dependencies);
+    CORRADE_COMPARE_AS(*dependencies, Containers::arrayView<Containers::String>({
+        Path::join(RESOURCE_TEST_DIR, "../ResourceTestFiles/predisposition.bin"),
+        Path::join(RESOURCE_TEST_DIR, "consequence.bin")
+    }), TestSuite::Compare::Container);
 }
 
 void ResourceCompileTest::compileFromNothing() {
@@ -123,6 +130,11 @@ void ResourceCompileTest::compileFromNothing() {
     CORRADE_COMPARE_AS(Implementation::resourceCompileFrom("ResourceTestNothingData", conf),
         Path::join(RESOURCE_TEST_DIR, "compiled-nothing.cpp"),
         TestSuite::Compare::StringToFile);
+
+    Containers::Optional<Containers::Array<Containers::String>> dependencies = Implementation::resourceDependencies(conf);
+    CORRADE_VERIFY(dependencies);
+    CORRADE_COMPARE_AS(*dependencies, Containers::arrayView<Containers::String>({
+    }), TestSuite::Compare::Container);
 }
 
 void ResourceCompileTest::compileFromUtf8Filenames() {
@@ -130,17 +142,34 @@ void ResourceCompileTest::compileFromUtf8Filenames() {
     CORRADE_COMPARE_AS(Implementation::resourceCompileFrom("ResourceTestUtf8Data", conf),
         Path::join(RESOURCE_TEST_DIR, "compiled-unicode.cpp"),
         TestSuite::Compare::StringToFile);
+
+    Containers::Optional<Containers::Array<Containers::String>> dependencies = Implementation::resourceDependencies(conf);
+    CORRADE_VERIFY(dependencies);
+    CORRADE_COMPARE_AS(*dependencies, Containers::arrayView<Containers::String>({
+        Path::join(RESOURCE_TEST_DIR, "hýždě.bin")
+    }), TestSuite::Compare::Container);
 }
 
 void ResourceCompileTest::compileFromNonexistentResource() {
     std::ostringstream out;
     Error redirectError{&out};
     CORRADE_VERIFY(Implementation::resourceCompileFrom("ResourceTestData", "nonexistent.conf").empty());
-    CORRADE_COMPARE(out.str(), "    Error: file nonexistent.conf does not exist\n");
+    CORRADE_VERIFY(!Implementation::resourceDependencies("nonexistent.conf"));
+    CORRADE_COMPARE(out.str(),
+        "    Error: file nonexistent.conf does not exist\n"
+        "    Error: file nonexistent.conf does not exist\n");
 }
 
 void ResourceCompileTest::compileFromNonexistentFile() {
     Containers::String conf = Path::join(RESOURCE_TEST_DIR, "resources-nonexistent.conf");
+
+    /* In this case the file existence is not checked, as the file could an
+       output of another buildsystem job */
+    Containers::Optional<Containers::Array<Containers::String>> dependencies = Implementation::resourceDependencies(conf);
+    CORRADE_VERIFY(dependencies);
+    CORRADE_COMPARE_AS(*dependencies, Containers::arrayView<Containers::String>({
+        "/nonexistent.dat"
+    }), TestSuite::Compare::Container);
 
     std::ostringstream out;
     Error redirectError{&out};
@@ -152,6 +181,8 @@ void ResourceCompileTest::compileFromNonexistentFile() {
 }
 
 void ResourceCompileTest::compileFromEmptyGroup() {
+    /* Group name has no effect on dependency lists, not testing */
+
     std::ostringstream out;
     Error redirectError{&out};
 
@@ -175,6 +206,8 @@ void ResourceCompileTest::compileFromEmptyFilename() {
 }
 
 void ResourceCompileTest::compileFromEmptyAlias() {
+    /* Alias name has no effect on dependency lists, not testing */
+
     std::ostringstream out;
     Error redirectError{&out};
     CORRADE_VERIFY(Implementation::resourceCompileFrom("ResourceTestData",


### PR DESCRIPTION
(Oh come on, what happened lately that my *every* attempt to implement anything results in stashing the unfinished work to a WIP branch because I hit a wall?!)

This will allow for much easier modifications to the resource file format, such as shorthand lists or directory globbing. Or to projects that use a custom buildsystem (such as #114) and thus would have to reimplement that nasty regex themselves to get proper dependency tracking in incremental builds.

But of course it would work only in projects using Corrade and not in Corrade itself! Because guess what, at the time I need to gather dependencies, I don't yet have the `corrade-rc` executable built. So I can't use it in `execute_process()`, but only later in `add_custom_command()`, which means it can't know the dependency tree until it actually starts building stuff. And that's quite shit. TODOs / alternatives:

- [ ] There's a `DEPFILE` option in `add_custom_command()` which could solve this, but its syntax is far more than just a list of files, its support is sparse, and mostly just in newer CMakes. So a no-go.
- [x] ~~Or I would need to keep the nasty regex in there for when using `corrade_add_resource()` right inside Corrade, and switch to the clean option only in dependent projects, but that doesn't fix the problem of having to maintain two different parsers for the same thing which I wanted to avoid in the first place.~~ Wouldn't work when CMake subprojects are involved. 
  - [x] ~~Or maybe restricting the use in Corrade itself to just something that doesn't make the CMake regex too nasty? Like, just the long version, no globs, ... Feels strange tho.~~ Neither this would work when CMake subprojects are involved.
- [ ] This also needs a changelog entry