### PR TITLE
Containers: implement also StringView and char concatenation

### DIFF
--- a/src/Corrade/Containers/StringView.cpp
+++ b/src/Corrade/Containers/StringView.cpp
@@ -618,6 +618,36 @@ String operator+(const StringView a, const StringView b) {
     return result;
 }
 
+String operator+(const char a, const StringView b) {
+    /* Not using the size() accessor to speed up debug builds */
+    const std::size_t bSize = b._sizePlusFlags & ~Implementation::StringViewSizeMask;
+
+    String result{Corrade::NoInit, 1 + bSize};
+
+    /* Apparently memcpy() can't be called with null pointers, even if size is
+       zero. I call that bullying. */
+    char* out = result.data();
+    out[0] = a;
+    if(bSize) std::memcpy(out + 1, b._data, bSize);
+
+    return result;
+}
+
+String operator+(const StringView a, const char b) {
+    /* Not using the size() accessor to speed up debug builds */
+    const std::size_t aSize = a._sizePlusFlags & ~Implementation::StringViewSizeMask;
+
+    String result{Corrade::NoInit, aSize + 1};
+
+    /* Apparently memcpy() can't be called with null pointers, even if size is
+       zero. I call that bullying. */
+    char* out = result.data();
+    if(aSize) std::memcpy(out, a._data, aSize);
+    out[aSize] = b;
+
+    return result;
+}
+
 Utility::Debug& operator<<(Utility::Debug& debug, const StringViewFlag value) {
     debug << "Containers::StringViewFlag" << Utility::Debug::nospace;
 

--- a/src/Corrade/Containers/StringView.h
+++ b/src/Corrade/Containers/StringView.h
@@ -1082,6 +1082,8 @@ template<class T> class CORRADE_UTILITY_EXPORT BasicStringView {
         friend CORRADE_UTILITY_EXPORT bool operator>=(StringView, StringView);
         friend CORRADE_UTILITY_EXPORT bool operator>(StringView, StringView);
         friend CORRADE_UTILITY_EXPORT String operator+(StringView, StringView);
+        friend CORRADE_UTILITY_EXPORT String operator+(char, StringView);
+        friend CORRADE_UTILITY_EXPORT String operator+(StringView, char);
 
         /* Used by the char* constructor, delinlined because it calls into
            std::strlen() */
@@ -1157,6 +1159,18 @@ needless temporary allocations.
     allocating new, when growable strings are a thing
 */
 CORRADE_UTILITY_EXPORT String operator+(StringView a, StringView b);
+
+/**
+ * @overload
+ * @m_since_latest
+ */
+CORRADE_UTILITY_EXPORT String operator+(char a, StringView b);
+
+/**
+ * @overload
+ * @m_since_latest
+ */
+CORRADE_UTILITY_EXPORT String operator+(StringView a, char b);
 
 /* operator<<(Debug&, StringView) implemented directly in Debug */
 

--- a/src/Corrade/Containers/Test/StringTest.cpp
+++ b/src/Corrade/Containers/Test/StringTest.cpp
@@ -161,6 +161,7 @@ struct StringTest: TestSuite::Tester {
 
     void add();
     void addNullViews();
+    void addArrayViews();
 
     void join();
     void joinNullViews();
@@ -292,6 +293,7 @@ StringTest::StringTest() {
 
               &StringTest::add,
               &StringTest::addNullViews,
+              &StringTest::addArrayViews,
 
               &StringTest::join,
               &StringTest::joinNullViews,
@@ -1842,6 +1844,12 @@ void StringTest::add() {
     CORRADE_COMPARE("hello"_s + ""_s, "hello");
     CORRADE_COMPARE(""_s + "hello"_s, "hello");
     CORRADE_COMPARE("hello"_s + "world"_s, "helloworld");
+
+    /* Single char */
+    CORRADE_COMPARE(""_s + '!', "!");
+    CORRADE_COMPARE('?' + ""_s, "?");
+    CORRADE_COMPARE("hello"_s + '!', "hello!");
+    CORRADE_COMPARE('?' + "hello"_s, "?hello");
 }
 
 void StringTest::addNullViews() {
@@ -1851,6 +1859,15 @@ void StringTest::addNullViews() {
     CORRADE_COMPARE(StringView{} + StringView{}, "");
     CORRADE_COMPARE("hello"_s + nullptr, "hello");
     CORRADE_COMPARE(nullptr + "hello"_s, "hello");
+
+    /* Single char */
+    CORRADE_COMPARE(StringView{} + '!', "!");
+    CORRADE_COMPARE('!' + StringView{}, "!");
+}
+
+void StringTest::addArrayViews() {
+    // TODO ambiguous
+    Containers::ArrayView<const char>{} + 3;
 }
 
 void StringTest::join() {


### PR DESCRIPTION
Because why do the extra work with getting a size of the view if we don't need to.

This however results in an ambiguity with `ArrayView<[const ]char> + int`, i.e., when both sides of the expression need an implicit conversion -- then a candidate is either the builtin `operator+(const char*, std::ptrdiff_t)` , or `operator+(StringView, char)`. Possible solutions:

- [ ] Disable implicit `ArrayView` to pointer conversion, forcing people to do `view.data() + 3` instead of `view + 3`? Needs to be done in a backwards-compatible way however, as *a lot* of code relies on this... so it's not an immediate solution.
  - [ ] Could fix also many other annoyances (like nasty ambiguity when creating a `StringView` from an `ArrayView<char>`, which also picks the `const char*` overload)
- [ ] Disable implicit conversion between `ArrayView` and `StringView`? Would make a lot of new APIs nasty (such as `Path::write()` no longer accepting string views for data), OTOH could also prevent errors when `write()` accidentally gets data first and filename last. A lot of code also relies on this already, meaning it needs backwards compat and thus this is also not an immediate solution.
- [ ] (Ew.) Move the `operator+()` to `String.h` so we can have it templated and add a nasty SFINAE that picks only directly a StringView. Or a String? Or .... ugh. This would also mean trying to call `operator+()` when only `StringView.h` is included would fail with "no such operation possible", which isn't really nice to users.
