### PR TITLE
Optimize TestSuite comparison macro compile times.

### DIFF
--- a/src/Corrade/TestSuite/CMakeLists.txt
+++ b/src/Corrade/TestSuite/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CorradeTestSuite_SRCS
     Comparator.cpp
     Tester.cpp
 
+    Compare/Container.cpp
     Compare/File.cpp
     Compare/FileToString.cpp
     Compare/FloatingPoint.cpp

--- a/src/Corrade/TestSuite/Comparator.cpp
+++ b/src/Corrade/TestSuite/Comparator.cpp
@@ -60,7 +60,7 @@ Utility::Debug& operator<<(Utility::Debug& debug, const ComparisonStatusFlags va
 
 namespace Implementation {
 
-void ComparatorBase::printMessage(ComparisonStatusFlags, Utility::Debug& out, const char* const actual, const char* const expected, void(*printer)(Utility::Debug&, const void*)) {
+void ComparatorBase::printMessage(ComparisonStatusFlags, Utility::Debug& out, const char* const actual, const char* const expected, void(*printer)(Utility::Debug&, const void*)) const {
     CORRADE_INTERNAL_ASSERT(actualValue && expectedValue);
     out << "Values" << actual << "and" << expected << "are not the same, actual is\n       ";
     printer(out, actualValue);

--- a/src/Corrade/TestSuite/Comparator.cpp
+++ b/src/Corrade/TestSuite/Comparator.cpp
@@ -27,6 +27,7 @@
 #include "Comparator.h"
 
 #include "Corrade/Containers/EnumSet.hpp"
+#include "Corrade/Containers/StringView.h"
 
 namespace Corrade { namespace TestSuite {
 
@@ -55,6 +56,24 @@ Utility::Debug& operator<<(Utility::Debug& debug, const ComparisonStatusFlags va
         ComparisonStatusFlag::Verbose,
         ComparisonStatusFlag::Diagnostic,
         ComparisonStatusFlag::VerboseDiagnostic});
+}
+
+namespace Implementation {
+
+void ComparatorBase::printMessage(ComparisonStatusFlags, Utility::Debug& out, const char* const actual, const char* const expected, void(*printer)(Utility::Debug&, const void*)) {
+    CORRADE_INTERNAL_ASSERT(actualValue && expectedValue);
+    out << "Values" << actual << "and" << expected << "are not the same, actual is\n       ";
+    printer(out, actualValue);
+    out << Utility::Debug::newline << "        but expected\n       ";
+    printer(out, expectedValue);
+}
+
+/* LCOV_EXCL_START */
+void ComparatorBase::saveDiagnostic(ComparisonStatusFlags, Utility::Debug&, Containers::StringView) {
+    CORRADE_INTERNAL_ASSERT_UNREACHABLE();
+}
+/* LCOV_EXCL_STOP */
+
 }
 
 }}

--- a/src/Corrade/TestSuite/Comparator.h
+++ b/src/Corrade/TestSuite/Comparator.h
@@ -114,15 +114,13 @@ namespace Implementation {
 
 class CORRADE_TESTSUITE_EXPORT ComparatorBase {
     public:
-        explicit ComparatorBase(): actualValue{}, expectedValue{} {}
-
-        void saveDiagnostic(ComparisonStatusFlags status, Utility::Debug& out, Containers::StringView path);
+        void saveDiagnostic(ComparisonStatusFlags status, Utility::Debug& out, Containers::StringView path); // TODO why even this??
 
     protected:
-        void printMessage(ComparisonStatusFlags status, Utility::Debug& out, const char* actual, const char* expected, void(*printer)(Utility::Debug&, const void*));
+        void printMessage(ComparisonStatusFlags status, Utility::Debug& out, const char* actual, const char* expected, void(*printer)(Utility::Debug&, const void*)) const;
 
-        const void* actualValue;
-        const void* expectedValue;
+        const void* actualValue{};
+        const void* expectedValue{};
 };
 
 }
@@ -276,7 +274,7 @@ template<class T> ComparisonStatusFlags Comparator<T>::operator()(const T& actua
     return ComparisonStatusFlag::Failed;
 }
 
-template<class T> void Comparator<T>::printMessage(ComparisonStatusFlags status, Utility::Debug& out, const char* actual, const char* expected) {
+template<class T> void Comparator<T>::printMessage(const ComparisonStatusFlags status, Utility::Debug& out, const char* const actual, const char* const expected) {
     Implementation::ComparatorBase::printMessage(status, out, actual, expected,
         [](Utility::Debug& out, const void* value) {
             out << *static_cast<const T*>(value);

--- a/src/Corrade/TestSuite/Compare/Container.cpp
+++ b/src/Corrade/TestSuite/Compare/Container.cpp
@@ -1,0 +1,62 @@
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Container.h"
+
+namespace Corrade { namespace TestSuite { namespace Implementation {
+
+void ContainerComparatorBase::printMessage(ComparisonStatusFlags, Utility::Debug& out, const char* const actual, const char* const expected, void(*printer)(Utility::Debug&, const void*), void(*itemPrinter)(Utility::Debug&, const void*, std::size_t)) const {
+    CORRADE_INTERNAL_ASSERT(_actualContents && _expectedContents);
+
+    out << "Containers" << actual << "and" << expected << "have different";
+    if(_actualContentsSize != _expectedContentsSize)
+        out << "size, actual" << _actualContentsSize << "but" << _expectedContentsSize << "expected. Actual contents:\n       ";
+    else
+        out << "contents, actual:\n       ";
+
+    printer(out, _actualContents);
+    out << Utility::Debug::newline << "        but expected\n       ";
+    printer(out, _expectedContents);
+    out << Utility::Debug::newline << "       ";
+
+    if(_actualContentsSize <= _firstDifferent) {
+        out << "Expected has";
+        itemPrinter(out, _expectedContents, _firstDifferent);
+    } else if(_expectedContentsSize <= _firstDifferent) {
+        out << "Actual has";
+        itemPrinter(out, _actualContents, _firstDifferent);
+    } else {
+        out << "Actual";
+        itemPrinter(out, _actualContents, _firstDifferent);
+        out << "but";
+        itemPrinter(out, _expectedContents, _firstDifferent);
+        out << "expected";
+    }
+
+    out << "on position" << _firstDifferent << Utility::Debug::nospace << ".";
+}
+
+}}}


### PR DESCRIPTION
I regularly get angry at how long large tests take to compile. Well, I guess relatively, building a *heavy* 6000-line `GltfImporterTest.cpp` in under 5 seconds is an unachievable feat in Some Other Codebases. But still.

Profiling using Clang `-ftime-trace`, the biggest offenders are:

- parsing the `<sstream>` include, about 160 ms / 3.5%  -- depends on making Debug stream-free, which depends on ... making my own float printers
- parsing `<cmath>`, about 40 ms / 1% -- can't really do much about this, and the more I optimize, the more this will stand out
- template instantiations, about 1000 ms / 20%, of which the biggest chunks are:
  - `TestSuite::Compare::Container<T>::printMessage()`, about 500 ms / 10% -- put it into a non-templated base. These are not so many but quite large.
    - The comparator also does the comparisons twice on error, which is fine at runtime but adds even more pain to compile times. Why not just remember the first different item instead, instead of looping through everything again?!
  - `TestSuite::Comparator<T>::printMessage()` -- put it into a non-templated base. These are tiny but quite many, so the template base might not help as much.

![image](https://user-images.githubusercontent.com/344828/171369232-ff1bff1b-9a3d-4e46-a68a-69bf767ae71d.png)

Comparison with [SpeedScope](https://www.speedscope.app) after adding a non-templated base for both `Comparator` and `Compare::Container` is above -- 4.9 seconds before, 4.5 after, time spent in `printMessage()` visibly shrinks. Trace files for reference: 

- [GltfImporterTest.cpp.original.zip](https://github.com/mosra/corrade/files/8812744/GltfImporterTest.cpp.original.zip)
- [GltfImporterTest.cpp.non-templated-base.zip](https://github.com/mosra/corrade/files/8812747/GltfImporterTest.cpp.non-templated-base.zip)

10% reduction in compile time is still not as significant as I hoped, further investigation needed:

- [ ] The actual container `operator<<()` seems to be quite heavy, anything to optimize there?
- [ ] What else?