### PR TITLE
Utility: make Path::move() use MoveFileEx() on Windows.

### DIFF
--- a/src/Corrade/Utility/Path.cpp
+++ b/src/Corrade/Utility/Path.cpp
@@ -422,8 +422,8 @@ bool move(Containers::StringView from, Containers::StringView to) {
     if(std::rename(Containers::String::nullTerminatedView(from).data(),
                Containers::String::nullTerminatedView(to).data()) != 0)
     #else
-    if(!MoveFileExW(Unicode::widen(from), Unicode::widen(to),
-                   MOVEFILE_REPLACE_EXISTING|MOVEFILE_COPY_ALLOWED))
+    if(MoveFileExW(Unicode::widen(from), Unicode::widen(to),
+                   MOVEFILE_REPLACE_EXISTING|MOVEFILE_COPY_ALLOWED) == 0)
     #endif
     {
         Error err;

--- a/src/Corrade/Utility/Path.cpp
+++ b/src/Corrade/Utility/Path.cpp
@@ -418,14 +418,14 @@ bool remove(const Containers::StringView path) {
 }
 
 bool move(Containers::StringView from, Containers::StringView to) {
-    if(
-        #ifndef CORRADE_TARGET_WINDOWS
-        std::rename(Containers::String::nullTerminatedView(from).data(),
-                    Containers::String::nullTerminatedView(to).data())
-        #else
-        _wrename(Unicode::widen(from), Unicode::widen(to))
-        #endif
-    != 0) {
+    #ifndef CORRADE_TARGET_WINDOWS
+    if(std::rename(Containers::String::nullTerminatedView(from).data(),
+               Containers::String::nullTerminatedView(to).data()) != 0)
+    #else
+    if(!MoveFileExW(Unicode::widen(from), Unicode::widen(to),
+                   MOVEFILE_REPLACE_EXISTING|MOVEFILE_COPY_ALLOWED))
+    #endif
+    {
         Error err;
         err << "Utility::Path::move(): can't move" << from << "to" << to << Debug::nospace << ":";
         Utility::Implementation::printErrnoErrorString(err, errno);

--- a/src/Corrade/Utility/Test/PathTest.cpp
+++ b/src/Corrade/Utility/Test/PathTest.cpp
@@ -116,6 +116,7 @@ struct PathTest: TestSuite::Tester {
     void moveDirectory();
     void moveSourceNonexistent();
     void moveDestinationNoPermission();
+    void moveDestinationExists();
     void moveNonNullTerminated();
     void moveUtf8();
 
@@ -308,6 +309,7 @@ PathTest::PathTest() {
               &PathTest::moveDirectory,
               &PathTest::moveSourceNonexistent,
               &PathTest::moveDestinationNoPermission,
+              &PathTest::moveDestinationExists,
               &PathTest::moveNonNullTerminated,
               &PathTest::moveUtf8,
 
@@ -1182,6 +1184,20 @@ void PathTest::moveDestinationNoPermission() {
         formatString("Utility::Path::move(): can't move {} to {}: error 13 (", from, to),
         TestSuite::Compare::StringHasPrefix);
     #endif
+}
+
+void PathTest::moveDestinationExists() {
+    /* Old file */
+    Containers::String oldFile = Path::join(_writeTestDir, "oldFile.txt");
+    CORRADE_VERIFY(Path::write(oldFile, "a"_s));
+
+    /* New file, should get overwritten */
+    Containers::String newFile = Path::join(_writeTestDir, "newFile.txt");
+    CORRADE_VERIFY(Path::write(newFile, "b"_s));
+
+    CORRADE_VERIFY(Path::move(oldFile, newFile));
+    CORRADE_VERIFY(!Path::exists(oldFile));
+    CORRADE_COMPARE_AS(newFile, "a", TestSuite::Compare::FileToString);
 }
 
 void PathTest::moveNonNullTerminated() {


### PR DESCRIPTION
This should prevent failures when the destination already exists. Also added a test to check the behaviour.

As mentioned on Gitter, the `MOVEFILE_COPY_ALLOWED` flag is only used when `to` is on a different volume than `from`, at least according to the Microsoft docs.