### PR TITLE
Utility: update Path::{home,configuration}Directory() on Windows.

### DIFF
--- a/src/Corrade/Utility/Path.cpp
+++ b/src/Corrade/Utility/Path.cpp
@@ -594,11 +594,18 @@ Containers::Optional<Containers::String> homeDirectory() {
 
     /* Windows (not Store/Phone) */
     #elif defined(CORRADE_TARGET_WINDOWS) && !defined(CORRADE_TARGET_WINDOWS_RT)
-    /** @todo get rid of MAX_PATH */
-    wchar_t h[MAX_PATH + 1];
+    wchar_t* h = nullptr;
+    Containers::ScopeGuard guard{h,
+        #ifdef CORRADE_MSVC2015_COMPATIBILITY
+        /* MSVC 2015 is unable to cast the parameter for CoTaskMemFree */
+        [](LPVOID path){ CoTaskMemFree(path); }
+        #else
+        CoTaskMemFree
+        #endif
+    };
     /* There doesn't seem to be any possibility how this could fail, so just
        assert */
-    CORRADE_INTERNAL_ASSERT(SHGetFolderPathW(nullptr, CSIDL_PERSONAL, nullptr, 0, h) == S_OK);
+    CORRADE_INTERNAL_ASSERT(SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_DEFAULT, nullptr, &h) == S_OK);
     return fromNativeSeparators(Unicode::narrow(h));
 
     /* Other */
@@ -640,11 +647,18 @@ Containers::Optional<Containers::String> configurationDirectory(const Containers
 
     /* Windows (not Store/Phone) */
     #elif defined(CORRADE_TARGET_WINDOWS) && !defined(CORRADE_TARGET_WINDOWS_RT)
-    /** @todo get rid of MAX_PATH */
-    wchar_t path[MAX_PATH];
+    wchar_t* path = nullptr;
+    Containers::ScopeGuard guard{path,
+        #ifdef CORRADE_MSVC2015_COMPATIBILITY
+        /* MSVC 2015 is unable to cast the parameter for CoTaskMemFree */
+        [](LPVOID path){ CoTaskMemFree(path); }
+        #else
+        CoTaskMemFree
+        #endif
+    };
     /* There doesn't seem to be any possibility how this could fail, so just
        assert */
-    CORRADE_INTERNAL_ASSERT(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0, path) == S_OK);
+    CORRADE_INTERNAL_ASSERT(SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_DEFAULT, nullptr, &path) == S_OK);
     if(path[0] == L'\0') {
         Error{} << "Utility::Path::configurationDirectory(): can't retrieve CSIDL_APPDATA";
         return {};

--- a/src/Corrade/Utility/Path.cpp
+++ b/src/Corrade/Utility/Path.cpp
@@ -598,7 +598,7 @@ Containers::Optional<Containers::String> homeDirectory() {
     Containers::ScopeGuard guard{h,
         #ifdef CORRADE_MSVC2015_COMPATIBILITY
         /* MSVC 2015 is unable to cast the parameter for CoTaskMemFree */
-        [](LPVOID path){ CoTaskMemFree(path); }
+        [](wchar_t* path){ CoTaskMemFree(path); }
         #else
         CoTaskMemFree
         #endif
@@ -651,7 +651,7 @@ Containers::Optional<Containers::String> configurationDirectory(const Containers
     Containers::ScopeGuard guard{path,
         #ifdef CORRADE_MSVC2015_COMPATIBILITY
         /* MSVC 2015 is unable to cast the parameter for CoTaskMemFree */
-        [](LPVOID path){ CoTaskMemFree(path); }
+        [](wchar_t* path){ CoTaskMemFree(path); }
         #else
         CoTaskMemFree
         #endif


### PR DESCRIPTION
Instead of the old `SHGetFolderPathW()` API, they now use the `SHGetKnownFolderPath()` API, which was added in Windows Vista.

As a side effect, if OneDrive is installed, `homeDirectory()` should now return the proper Documents directory, instead of the OneDrive equivalent. Though I couldn't test that, because I made sure to remove it from my machine as soon as possible.