### PR TITLE
Utility: use Corrade String and StringView in ConfigurationValue

### DIFF
--- a/doc/snippets/Utility.cpp
+++ b/doc/snippets/Utility.cpp
@@ -75,11 +75,11 @@ namespace Corrade { namespace Utility {
 template<> struct ConfigurationValue<Foo> {
     static std::string toString(const Foo& value, ConfigurationValueFlags flags) {
         return
-            ConfigurationValue<int>::toString(value.a, flags) + ' ' +
+            ConfigurationValue<int>::toString(value.a, flags) + " " +
             ConfigurationValue<int>::toString(value.b, flags);
     }
 
-    static Foo fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
+    static Foo fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
         std::istringstream i{stringValue};
         std::string a, b;
 

--- a/src/Corrade/Utility/Arguments.h
+++ b/src/Corrade/Utility/Arguments.h
@@ -36,6 +36,7 @@
 #include "Corrade/Containers/Array.h"
 #include "Corrade/Containers/StringStl.h"
 #include "Corrade/Utility/ConfigurationValue.h"
+#include "Corrade/Utility/ConfigurationValueStl.h"
 #include "Corrade/Utility/StlForwardVector.h"
 #include "Corrade/Utility/Utility.h"
 #include "Corrade/Utility/visibility.h"

--- a/src/Corrade/Utility/CMakeLists.txt
+++ b/src/Corrade/Utility/CMakeLists.txt
@@ -72,6 +72,7 @@ if(CORRADE_WITH_UTILITY)
         Configuration.h
         ConfigurationGroup.h
         ConfigurationValue.h
+        ConfigurationValueStl.h
         Debug.h
         DebugAssert.h
         DebugStl.h

--- a/src/Corrade/Utility/ConfigurationValue.cpp
+++ b/src/Corrade/Utility/ConfigurationValue.cpp
@@ -34,22 +34,22 @@
 
 namespace Corrade { namespace Utility {
 
-Containers::StringView ConfigurationValue<Containers::StringView>::fromString(const std::string& value, ConfigurationValueFlags) {
+Containers::StringView ConfigurationValue<Containers::StringView>::fromString(Containers::StringView value, ConfigurationValueFlags) {
     return value;
 }
-std::string ConfigurationValue<Containers::StringView>::toString(const Containers::StringView value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<Containers::StringView>::toString(const Containers::StringView value, ConfigurationValueFlags) {
     return value;
 }
 
-Containers::String ConfigurationValue<Containers::String>::fromString(const std::string& value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<Containers::String>::fromString(Containers::StringView value, ConfigurationValueFlags) {
     return value;
 }
-std::string ConfigurationValue<Containers::String>::toString(const Containers::String& value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<Containers::String>::toString(const Containers::String& value, ConfigurationValueFlags) {
     return value;
 }
 
 namespace Implementation {
-    template<class T> std::string IntegerConfigurationValue<T>::toString(const T& value, ConfigurationValueFlags flags) {
+    template<class T> Containers::String IntegerConfigurationValue<T>::toString(const T& value, ConfigurationValueFlags flags) {
         std::ostringstream stream;
 
         /* Hexadecimal / octal values */
@@ -65,8 +65,8 @@ namespace Implementation {
         return stream.str();
     }
 
-    template<class T> T IntegerConfigurationValue<T>::fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
-        if(stringValue.empty()) return T{};
+    template<class T> T IntegerConfigurationValue<T>::fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
+        if(stringValue.isEmpty()) return T{};
 
         std::istringstream stream{stringValue};
 
@@ -93,7 +93,7 @@ namespace Implementation {
     template struct IntegerConfigurationValue<long long>;
     template struct IntegerConfigurationValue<unsigned long long>;
 
-    template<class T> std::string FloatConfigurationValue<T>::toString(const T& value, ConfigurationValueFlags flags) {
+    template<class T> Containers::String FloatConfigurationValue<T>::toString(const T& value, ConfigurationValueFlags flags) {
         std::ostringstream stream;
 
         /* Scientific notation */
@@ -107,8 +107,8 @@ namespace Implementation {
         return stream.str();
     }
 
-    template<class T> T FloatConfigurationValue<T>::fromString(const std::string& stringValue, ConfigurationValueFlags flags) {
-        if(stringValue.empty()) return T{};
+    template<class T> T FloatConfigurationValue<T>::fromString(Containers::StringView stringValue, ConfigurationValueFlags flags) {
+        if(stringValue.isEmpty()) return T{};
 
         std::istringstream stream{stringValue};
 
@@ -130,24 +130,17 @@ namespace Implementation {
 }
 
 #ifndef DOXYGEN_GENERATING_OUTPUT
-std::string ConfigurationValue<std::string>::fromString(const std::string& value, ConfigurationValueFlags) {
-    return value;
-}
-std::string ConfigurationValue<std::string>::toString(const std::string& value, ConfigurationValueFlags) {
-    return value;
-}
-
-bool ConfigurationValue<bool>::fromString(const std::string& value, ConfigurationValueFlags) {
+bool ConfigurationValue<bool>::fromString(Containers::StringView value, ConfigurationValueFlags) {
     return value == "1" || value == "yes" || value == "y" || value == "true";
 }
-std::string ConfigurationValue<bool>::toString(const bool value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<bool>::toString(const bool value, ConfigurationValueFlags) {
     return value ? "true" : "false";
 }
 
-char32_t ConfigurationValue<char32_t>::fromString(const std::string& value, ConfigurationValueFlags) {
+char32_t ConfigurationValue<char32_t>::fromString(Containers::StringView value, ConfigurationValueFlags) {
     return char32_t(ConfigurationValue<unsigned long long>::fromString(value, ConfigurationValueFlag::Hex|ConfigurationValueFlag::Uppercase));
 }
-std::string ConfigurationValue<char32_t>::toString(const char32_t value, ConfigurationValueFlags) {
+Containers::String ConfigurationValue<char32_t>::toString(const char32_t value, ConfigurationValueFlags) {
     return ConfigurationValue<unsigned long long>::toString(value, ConfigurationValueFlag::Hex|ConfigurationValueFlag::Uppercase);
 }
 #endif

--- a/src/Corrade/Utility/ConfigurationValue.h
+++ b/src/Corrade/Utility/ConfigurationValue.h
@@ -31,7 +31,6 @@
  */
 
 #include "Corrade/Containers/EnumSet.h"
-#include "Corrade/Utility/StlForwardString.h"
 #include "Corrade/Utility/visibility.h"
 
 namespace Corrade { namespace Utility {
@@ -92,7 +91,7 @@ template<class T> struct ConfigurationValue {
     * @param flags         Flags
     * @return Value as string
     */
-    static std::string toString(const T& value, ConfigurationValueFlags flags);
+    static Containers::String toString(const T& value, ConfigurationValueFlags flags);
 
     /**
     * @brief Convert value from string
@@ -100,7 +99,7 @@ template<class T> struct ConfigurationValue {
     * @param flags         Flags
     * @return Value
     */
-    static T fromString(const std::string& stringValue, ConfigurationValueFlags flags);
+    static T fromString(Containers::StringView stringValue, ConfigurationValueFlags flags);
     #endif
 };
 
@@ -115,8 +114,8 @@ template<> struct CORRADE_UTILITY_EXPORT ConfigurationValue<Containers::StringVi
     ConfigurationValue() = delete;
 
     #ifndef DOXYGEN_GENERATING_OUTPUT
-    static Containers::StringView fromString(const std::string& value, ConfigurationValueFlags flags);
-    static std::string toString(Containers::StringView value, ConfigurationValueFlags flags);
+    static Containers::StringView fromString(Containers::StringView value, ConfigurationValueFlags flags);
+    static Containers::String toString(Containers::StringView value, ConfigurationValueFlags flags);
     #endif
 };
 
@@ -131,8 +130,8 @@ template<> struct CORRADE_UTILITY_EXPORT ConfigurationValue<Containers::String> 
     ConfigurationValue() = delete;
 
     #ifndef DOXYGEN_GENERATING_OUTPUT
-    static Containers::String fromString(const std::string& value, ConfigurationValueFlags flags);
-    static std::string toString(const Containers::String& value, ConfigurationValueFlags flags);
+    static Containers::String fromString(Containers::StringView value, ConfigurationValueFlags flags);
+    static Containers::String toString(const Containers::String& value, ConfigurationValueFlags flags);
     #endif
 };
 
@@ -140,14 +139,14 @@ namespace Implementation {
     template<class T> struct CORRADE_UTILITY_EXPORT IntegerConfigurationValue {
         IntegerConfigurationValue() = delete;
 
-        static std::string toString(const T& value, ConfigurationValueFlags flags);
-        static T fromString(const std::string& stringValue, ConfigurationValueFlags flags);
+        static Containers::String toString(const T& value, ConfigurationValueFlags flags);
+        static T fromString(Containers::StringView stringValue, ConfigurationValueFlags flags);
     };
     template<class T> struct CORRADE_UTILITY_EXPORT FloatConfigurationValue {
         FloatConfigurationValue() = delete;
 
-        static std::string toString(const T& value, ConfigurationValueFlags flags);
-        static T fromString(const std::string& stringValue, ConfigurationValueFlags flags);
+        static Containers::String toString(const T& value, ConfigurationValueFlags flags);
+        static T fromString(Containers::StringView stringValue, ConfigurationValueFlags flags);
     };
 }
 
@@ -233,16 +232,6 @@ digits on platforms with 80-bit @cpp long double @ce and 15 digits on platforms
 */
 template<> struct ConfigurationValue<long double>: public Implementation::FloatConfigurationValue<long double> {};
 
-/** @brief Configuration value parser and writer for @ref std::string type */
-template<> struct CORRADE_UTILITY_EXPORT ConfigurationValue<std::string> {
-    ConfigurationValue() = delete;
-
-    #ifndef DOXYGEN_GENERATING_OUTPUT
-    static std::string fromString(const std::string& value, ConfigurationValueFlags flags);
-    static std::string toString(const std::string& value, ConfigurationValueFlags flags);
-    #endif
-};
-
 /**
 @brief Configuration value parser and writer for `bool` type
 
@@ -253,8 +242,8 @@ template<> struct CORRADE_UTILITY_EXPORT ConfigurationValue<bool> {
     ConfigurationValue() = delete;
 
     #ifndef DOXYGEN_GENERATING_OUTPUT
-    static bool fromString(const std::string& value, ConfigurationValueFlags flags);
-    static std::string toString(bool value, ConfigurationValueFlags flags);
+    static bool fromString(Containers::StringView value, ConfigurationValueFlags flags);
+    static Containers::String toString(bool value, ConfigurationValueFlags flags);
     #endif
 };
 
@@ -267,8 +256,8 @@ template<> struct CORRADE_UTILITY_EXPORT ConfigurationValue<char32_t> {
     ConfigurationValue() = delete;
 
     #ifndef DOXYGEN_GENERATING_OUTPUT
-    static char32_t fromString(const std::string& value, ConfigurationValueFlags);
-    static std::string toString(char32_t value, ConfigurationValueFlags);
+    static char32_t fromString(Containers::StringView value, ConfigurationValueFlags);
+    static Containers::String toString(char32_t value, ConfigurationValueFlags);
     #endif
 };
 

--- a/src/Corrade/Utility/ConfigurationValueStl.h
+++ b/src/Corrade/Utility/ConfigurationValueStl.h
@@ -1,0 +1,55 @@
+#ifndef Corrade_Utility_ConfigurationValueStl_h
+#define Corrade_Utility_ConfigurationValueStl_h
+/*
+    This file is part of Corrade.
+
+    Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+                2017, 2018, 2019, 2020, 2021, 2022
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+@brief STL @ref std::string compatibility for @ref Corrade::Utility::ConfigurationValue
+ */
+
+#include <string>
+#include "Corrade/Utility/ConfigurationValue.h"
+#include "Corrade/Utility/visibility.h"
+
+namespace Corrade { namespace Utility {
+
+/** @brief Configuration value parser and writer for @ref std::string type */
+template <> struct CORRADE_UTILITY_EXPORT ConfigurationValue<std::string> {
+    ConfigurationValue() = delete;
+
+#ifndef DOXYGEN_GENERATING_OUTPUT
+    static std::string fromString(Containers::StringView value, ConfigurationValueFlags) {
+        return value;
+    }
+    static Containers::String toString(const std::string& value, ConfigurationValueFlags) {
+        return value;
+    }
+#endif
+};
+
+}}
+
+#endif

--- a/src/Corrade/Utility/Test/ConfigurationValueTest.cpp
+++ b/src/Corrade/Utility/Test/ConfigurationValueTest.cpp
@@ -49,7 +49,7 @@ template<> struct ConfigurationValue<NoDefaultConstructor> {
     static std::string toString(NoDefaultConstructor value, ConfigurationValueFlags) {
         return std::string(value.a, 'a');
     }
-    static NoDefaultConstructor fromString(const std::string& stringValue, ConfigurationValueFlags) {
+    static NoDefaultConstructor fromString(Containers::StringView stringValue, ConfigurationValueFlags) {
         return NoDefaultConstructor{stringValue.size()};
     }
 };


### PR DESCRIPTION
Hello !
We're trying to optimize our compile times and I noticed that `StlForwardString.h` is actually very heavy on MSVC because it just directly includes `<string>`, so I thought let's go and try to clean up  `ConfigurationValue`.
I'll open the associated Magnum PR right away. Let me know if I'm going at this correctly 😅 