### PR TITLE
Add missing noexcept for some move ctors/assigns

### DIFF
--- a/src/Corrade/Utility/Configuration.cpp
+++ b/src/Corrade/Utility/Configuration.cpp
@@ -72,14 +72,14 @@ Configuration::Configuration(std::istream& in, const Flags flags): Configuration
     if(parse({data.data(), data.size()})) _flags |= InternalFlag::IsValid;
 }
 
-Configuration::Configuration(Configuration&& other): ConfigurationGroup{std::move(other)}, _filename{std::move(other._filename)}, _flags{other._flags} {
+Configuration::Configuration(Configuration&& other) noexcept: ConfigurationGroup{std::move(other)}, _filename{std::move(other._filename)}, _flags{other._flags} {
     /* Redirect configuration pointer to this instance */
     setConfigurationPointer(this);
 }
 
 Configuration::~Configuration() { if(_flags & InternalFlag::Changed) save(); }
 
-Configuration& Configuration::operator=(Configuration&& other) {
+Configuration& Configuration::operator=(Configuration&& other) noexcept {
     ConfigurationGroup::operator=(std::move(other));
     _filename = std::move(other._filename);
     _flags = other._flags;

--- a/src/Corrade/Utility/Configuration.h
+++ b/src/Corrade/Utility/Configuration.h
@@ -299,7 +299,7 @@ class CORRADE_UTILITY_EXPORT Configuration: public ConfigurationGroup {
         Configuration(const Configuration&) = delete;
 
         /** @brief Move constructor */
-        Configuration(Configuration&& other);
+        Configuration(Configuration&& other) noexcept;
 
         /**
          * @brief Destructor
@@ -312,7 +312,7 @@ class CORRADE_UTILITY_EXPORT Configuration: public ConfigurationGroup {
         Configuration& operator=(const Configuration&) = delete;
 
         /** @brief Move assignment */
-        Configuration& operator=(Configuration&& other);
+        Configuration& operator=(Configuration&& other) noexcept;
 
         /** @brief Filename in UTF-8 */
         std::string filename() const;

--- a/src/Corrade/Utility/ConfigurationGroup.cpp
+++ b/src/Corrade/Utility/ConfigurationGroup.cpp
@@ -88,7 +88,7 @@ ConfigurationGroup::ConfigurationGroup(const ConfigurationGroup& other): _values
         group.group = new ConfigurationGroup(*group.group);
 }
 
-ConfigurationGroup::ConfigurationGroup(ConfigurationGroup&& other): _values(std::move(other._values)), _groups(std::move(other._groups)), _configuration(nullptr) {
+ConfigurationGroup::ConfigurationGroup(ConfigurationGroup&& other) noexcept: _values(std::move(other._values)), _groups(std::move(other._groups)), _configuration(nullptr) {
     /* Reset configuration pointer for subgroups */
     for(Group& group: _groups)
         group.group->_configuration = nullptr;
@@ -112,7 +112,7 @@ ConfigurationGroup& ConfigurationGroup::operator=(const ConfigurationGroup& othe
     return *this;
 }
 
-ConfigurationGroup& ConfigurationGroup::operator=(ConfigurationGroup&& other) {
+ConfigurationGroup& ConfigurationGroup::operator=(ConfigurationGroup&& other) noexcept {
     /* Delete current groups */
     for(Group& group: _groups)
         delete group.group;

--- a/src/Corrade/Utility/ConfigurationGroup.h
+++ b/src/Corrade/Utility/ConfigurationGroup.h
@@ -105,7 +105,7 @@ class CORRADE_UTILITY_EXPORT ConfigurationGroup {
          * Pointer to enclosing configuration is set to @cpp nullptr @ce, call
          * @ref addGroup() to add it somewhere.
          */
-        ConfigurationGroup(ConfigurationGroup&& other);
+        ConfigurationGroup(ConfigurationGroup&& other) noexcept;
 
         ~ConfigurationGroup();
 
@@ -125,7 +125,7 @@ class CORRADE_UTILITY_EXPORT ConfigurationGroup {
          * object.
          * @see @ref configuration()
          */
-        ConfigurationGroup& operator=(ConfigurationGroup&& other);
+        ConfigurationGroup& operator=(ConfigurationGroup&& other) noexcept;
 
         /**
          * @brief Enclosing configuration


### PR DESCRIPTION
I applied some fixes with the latest clang-tidy tools to Corrade. Mainly some missing noexcept specifies for move assignments, which will allow it to use move operations in STL containers. 

LinkedLIst could also have some methods marked as noexcept, although they would not actually be noexcept with CORRADE_ASSERTS (in debug mode). They are noexcept in Release Mode though.