### PR TITLE
PluginManager: fix static test build

### DIFF
--- a/src/Corrade/PluginManager/Test/animals/CMakeLists.txt
+++ b/src/Corrade/PluginManager/Test/animals/CMakeLists.txt
@@ -73,6 +73,6 @@ if((CORRADE_BUILD_STATIC OR CORRADE_TARGET_WINDOWS) AND NOT CORRADE_PLUGINMANAGE
 endif()
 
 # Additionally the plugin dependencies have to be linked as well
-if(CORRADE_TARGET_WINDOWS)
+if(CORRADE_TARGET_WINDOWS AND NOT CORRADE_PLUGINMANAGER_NO_DYNAMIC_PLUGIN_SUPPORT)
     target_link_libraries(PitBull PRIVATE Dog)
 endif()


### PR DESCRIPTION
This was preventing cmake configuring from finishing.