### PR TITLE
debuggers: move license comment in MSVC natvis file into the root

### DIFF
--- a/src/debuggers/natvis/corrade.natvis
+++ b/src/debuggers/natvis/corrade.natvis
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <!--
     This file is part of Corrade.
 
@@ -26,7 +28,6 @@
     DEALINGS IN THE SOFTWARE.
 -->
 
-<?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
   <!-- Containers::Array -->
   <Type Name="Corrade::Containers::Array&lt;*&gt;">


### PR DESCRIPTION
XML doesn't allow having anything before the root, and MSVC being diligent refuses to parse the .natvis file