### PR TITLE
debuggers: adapt MSVC natvis to recent String changes

### DIFF
--- a/src/debuggers/natvis/corrade.natvis
+++ b/src/debuggers/natvis/corrade.natvis
@@ -172,6 +172,7 @@
       <Synthetic Name="[deleter]" ExcludeView="simple" Condition="!isSmall() &amp;&amp; _large.deleter == nullptr">
         <DisplayString>operator delete[]</DisplayString>
       </Synthetic>
+      <Item Name="[small]" ExcludeView="simple">isSmall()</Item>
       <ArrayItems>
         <Size>size()</Size>
         <ValuePointer>data()</ValuePointer>

--- a/src/debuggers/natvis/corrade.natvis
+++ b/src/debuggers/natvis/corrade.natvis
@@ -158,9 +158,9 @@
   </Type>
   <!-- Containers::String -->
   <Type Name="Corrade::Containers::String">
-    <Intrinsic Name="isSmall" Expression="(_small.size &amp; 0x80) != 0"/>
+    <Intrinsic Name="isSmall" Expression="(_small.size &amp; Implementation::SmallStringBit) != 0"/>
     <Intrinsic Name="data" Expression="isSmall() ? _small.data : _large.data"/>
-    <Intrinsic Name="size" Expression="isSmall() ? _small.size &amp; ~0x80 : _large.size"/>
+    <Intrinsic Name="size" Expression="isSmall() ? _small.size &amp; ~Implementation::SmallStringBit : _large.size"/>
     <!-- String is null-terminated, but can include null-characters before the end, so use explicit size -->
     <!-- Display as UTF-8 -->
     <DisplayString>{data(),[size()]s8}</DisplayString>


### PR DESCRIPTION
Small fix to make the .natvis file work with current master again 🍒 And I made MSVC show you whether a string is small-size-optimized or not, sometimes handy to know.