### PR TITLE
debuggers: update MSVC .natvis definitions

### DIFF
--- a/src/debuggers/natvis/corrade.natvis
+++ b/src/debuggers/natvis/corrade.natvis
@@ -130,6 +130,21 @@
       <ExpandedItem>_reference</ExpandedItem>
     </Expand>
   </Type>
+  <!-- Containers::MoveReference -->
+  <Type Name="Corrade::Containers::MoveReference&lt;*&gt;">
+    <DisplayString>{*_reference,na}</DisplayString>
+    <Expand>
+      <ExpandedItem>*_reference</ExpandedItem>
+    </Expand>
+  </Type>
+  <!-- Containers::AnyReference -->
+  <Type Name="Corrade::Containers::AnyReference&lt;*&gt;">
+    <DisplayString>{*_reference,na}</DisplayString>
+    <Expand>
+      <Item Name="[r-value]" ExcludeView="simple">_isRvalue</Item>
+      <ExpandedItem>*_reference</ExpandedItem>
+    </Expand>
+  </Type>
   <!-- Containers::StaticArray -->
   <Type Name="Corrade::Containers::StaticArray&lt;*&gt;">
     <DisplayString>{{ size={$T1} }}</DisplayString>

--- a/src/debuggers/natvis/corrade.natvis
+++ b/src/debuggers/natvis/corrade.natvis
@@ -78,7 +78,7 @@
     <Expand>
       <IndexListItems>
         <Size>size()</Size>
-        <ValueNode>(bool)(_data[(offset() + $i)/8] &amp; (1 &lt;&lt; ((offset() + $i)%8)))</ValueNode>
+        <ValueNode>(bool)((($T1*)_data)[(offset() + $i)/8] &amp; (1 &lt;&lt; ((offset() + $i)%8)))</ValueNode>
       </IndexListItems>
     </Expand>
   </Type>


### PR DESCRIPTION
- Adds definitions for `MoveReference` and `AnyReference`
- Fixes definition for `BitArrayView` after changes in https://github.com/mosra/corrade/commit/cbc700a614202f7e4d2c366ca8fec123af3fa8c5