### PR TITLE
Attempt to fix the iOS CI build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,22 @@ elseif(UNIX)
     if(APPLE)
         set(CORRADE_TARGET_APPLE 1)
 
-        if(CMAKE_OSX_SYSROOT MATCHES "/iPhoneOS[0-9.]*\\.sdk")
+        # Since CMake 3.14, setting CMAKE_SYSTEM_NAME to iOS and not using any
+        # explicit toolchain file is the builtin way to build for iOS, not by
+        # overriding CMAKE_OSX_SYSROOT. For backwards compatiblity the
+        # CMAKE_OSX_SYSROOT check is present as well, but it isn't expected to
+        # be set anymore.
+        #
+        # CMAKE_OSX_SYSROOT originally also used to be used for switching
+        # between a device and a simulator build. Nowadays, an iOS binary is
+        # often made "fat", containing both device and simulator code, and
+        # building for either a device or the simulator is controlled via a
+        # -sdk option passed at the *build* time, i.e. there's no way to know
+        # whether it'll be a simulator at the *configure* time. Thus
+        # CORRADE_TARGET_IOS_SIMULATOR is no longer set.
+        if(CMAKE_SYSTEM_NAME STREQUAL iOS)
+            set(CORRADE_TARGET_IOS 1)
+        elseif(CMAKE_OSX_SYSROOT MATCHES "/iPhoneOS[0-9.]*\\.sdk")
             set(CORRADE_TARGET_IOS 1)
         elseif(CMAKE_OSX_SYSROOT MATCHES "/iPhoneSimulator[0-9.]*\\.sdk")
             set(CORRADE_TARGET_IOS 1)

--- a/modules/UseCorrade.cmake
+++ b/modules/UseCorrade.cmake
@@ -450,18 +450,20 @@ function(corrade_add_test test_name)
                        ${test_runner_file})
         xctest_add_bundle(${test_name}Runner ${test_name} ${test_runner_file})
         if(CORRADE_TARGET_IOS)
-            # The EFFECTIVE_PLATFORM_NAME variable is not expanded when using
-            # TARGET_* generator expressions on iOS, we need to hardcode it
-            # manually. See http://public.kitware.com/pipermail/cmake/2016-March/063049.html
-            # In case we redirect the runtime output directory, use that (and
-            # assume there's no TARGET_* generator expression). This will of
-            # course break when someone sets the LIBRARY_OUTPUT_DIRECTORY
-            # property of the target, but that didn't work before either.
-            if(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-                add_test(NAME ${test_name} COMMAND ${XCTest_EXECUTABLE} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${test_name}Runner.xctest)
-            else()
-                add_test(NAME ${test_name} COMMAND ${XCTest_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>${_CORRADE_EFFECTIVE_PLATFORM_NAME}/${test_name}Runner.xctest)
+            if(NOT CORRADE_TESTSUITE_XCTEST_DESTINATION)
+                message(FATAL_ERROR "On iOS with CORRADE_TESTSUITE_TARGET_XCTEST enabled you need to set CORRADE_TESTSUITE_XCTEST_DESTINATION to a destination on which the tests should be run, such as \"platform=iOS Simulator,name=iPhone 12\"")
             endif()
+            add_test(NAME ${test_name}
+                # TODO Running build-for-testing and then
+                #   xcodebuild -xctestrun ${test_name}Runner.*.xctestrun
+                # with the generated files is significantly faster (probably
+                # because it doesn't need to parse the whole project every
+                # time), but so far I don't see how to run that as part of the
+                # build for all schemes
+                COMMAND xcodebuild test-without-building -scheme ${test_name}Runner -destination "${CORRADE_TESTSUITE_XCTEST_DESTINATION}" -only-testing:${test_name}Runner -only-test-configuration $<CONFIG>
+                # Has to be run in the directory where the xcodeproj is
+                # generated
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
         else()
             xctest_add_test(${test_name} ${test_name}Runner)
         endif()

--- a/modules/UseCorrade.cmake
+++ b/modules/UseCorrade.cmake
@@ -460,7 +460,7 @@ function(corrade_add_test test_name)
                 # because it doesn't need to parse the whole project every
                 # time), but so far I don't see how to run that as part of the
                 # build for all schemes
-                COMMAND xcodebuild test-without-building -scheme ${test_name}Runner -destination "${CORRADE_TESTSUITE_XCTEST_DESTINATION}" -only-testing:${test_name}Runner -only-test-configuration $<CONFIG>
+                COMMAND xcodebuild test-without-building -scheme ${test_name}Runner -configuration $<CONFIG> -destination "${CORRADE_TESTSUITE_XCTEST_DESTINATION}" -only-testing:${test_name}Runner
                 # Has to be run in the directory where the xcodeproj is
                 # generated
                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/package/ci/circleci.yml
+++ b/package/ci/circleci.yml
@@ -444,40 +444,40 @@ workflows:
     # if they pass, the rest of the jobs gets gradually executed, with further
     # dependencies especially for the macOS jobs that take the most credits.
     jobs:
-    - linux
-    - linux-nondeprecated
-    - linux-arm64:
-        requires:
-        - linux
-        - linux-nondeprecated
-    - linux-static:
-        requires:
-        - linux
-        - linux-nondeprecated
-    - linux-sanitizers:
-        requires:
-        - linux
-        - linux-nondeprecated
-    - linux-threadsanitizer:
-        requires:
-        - linux-sanitizers
-    - macos:
-        requires:
-        - linux
-        - linux-nondeprecated
-    - macos-static:
-        requires:
-        - macos
-        - linux-static
-    - emscripten:
-        requires:
-        - linux-static
-    - android-x86:
-        requires:
-        - linux-static
-        - linux-arm64
-    - ios:
-        requires:
-        - macos-static
-        - linux-arm64
-    - acme
+    # - linux
+    # - linux-nondeprecated
+    # - linux-arm64:
+    #     requires:
+    #     - linux
+    #     - linux-nondeprecated
+    # - linux-static:
+    #     requires:
+    #     - linux
+    #     - linux-nondeprecated
+    # - linux-sanitizers:
+    #     requires:
+    #     - linux
+    #     - linux-nondeprecated
+    # - linux-threadsanitizer:
+    #     requires:
+    #     - linux-sanitizers
+    # - macos:
+    #     requires:
+    #     - linux
+    #     - linux-nondeprecated
+    # - macos-static:
+    #     requires:
+    #     - macos
+    #     - linux-static
+    # - emscripten:
+    #     requires:
+    #     - linux-static
+    # - android-x86:
+    #     requires:
+    #     - linux-static
+    #     - linux-arm64
+    - ios
+    #     requires:
+    #     - macos-static
+    #     - linux-arm64
+    # - acme

--- a/package/ci/ios-simulator.sh
+++ b/package/ci/ios-simulator.sh
@@ -27,8 +27,15 @@ cmake .. \
     -DCORRADE_BUILD_STATIC=ON \
     -DCORRADE_BUILD_TESTS=ON \
     -DCORRADE_TESTSUITE_TARGET_XCTEST=ON \
+    -DCORRADE_TESTSUITE_XCTEST_DESTINATION="platform=iOS Simulator,name=iPhone 8" \
     -G Xcode
 set -o pipefail && cmake --build . --config Release -j$XCODE_JOBS -- -sdk iphonesimulator | xcbeautify
+
+# Boot a simulator before running tests. It's not required, but makes the tests
+# run significantly faster (apparently because it then doesn't have to boot and
+# shutdown a simulator every time?? ugh)
+xcrun simctl boot "iPhone 8"
+
 CORRADE_TEST_COLOR=ON ctest -V -C Release
 
 # Test install, after running the tests as for them it shouldn't be needed

--- a/package/ci/ios-simulator.sh
+++ b/package/ci/ios-simulator.sh
@@ -19,17 +19,17 @@ cd ..
 # Crosscompile
 mkdir build-ios && cd build-ios
 cmake .. \
-    -DCMAKE_TOOLCHAIN_FILE=../toolchains/generic/iOS.cmake \
-    -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk \
+    -DCMAKE_SYSTEM_NAME=iOS \
     -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+    -DCMAKE_OSX_SYSROOT=iphonesimulator \
     -DCORRADE_RC_EXECUTABLE=$HOME/deps-native/bin/corrade-rc \
     -DCMAKE_INSTALL_PREFIX=$HOME/deps \
     -DCORRADE_BUILD_STATIC=ON \
     -DCORRADE_BUILD_TESTS=ON \
     -DCORRADE_TESTSUITE_TARGET_XCTEST=ON \
     -G Xcode
-set -o pipefail && cmake --build . --config Release -j$XCODE_JOBS | xcbeautify
+set -o pipefail && cmake --build . --config Release -j$XCODE_JOBS -- -sdk iphonesimulator | xcbeautify
 CORRADE_TEST_COLOR=ON ctest -V -C Release
 
 # Test install, after running the tests as for them it shouldn't be needed
-set -o pipefail && cmake --build . --config Release --target install -j$XCODE_JOBS | xcbeautify
+set -o pipefail && cmake --build . --config Release --target install -j$XCODE_JOBS -- -sdk iphonesimulator | xcbeautify

--- a/src/Corrade/Utility/Test/CMakeLists.txt
+++ b/src/Corrade/Utility/Test/CMakeLists.txt
@@ -423,6 +423,13 @@ if(CORRADE_BUILD_STATIC AND NOT CORRADE_TARGET_EMSCRIPTEN AND NOT CORRADE_TARGET
     add_library(UtilityGlobalStateAcrossLibrariesLibrary SHARED
         GlobalStateAcrossLibrariesLibrary.cpp
         ${ResourceTestData})
+    if(CMAKE_GENERATOR STREQUAL Xcode)
+        # Xcode's "new build system" doesn't like when the same (generated)
+        # source file is used by two different targets (ResourceTestDataLib and
+        # UtilityGlobalStateAcrossLibrariesLibrary) that don't have any other
+        # dependency between them. WTF.
+        add_dependencies(UtilityGlobalStateAcrossLibrariesLibrary ResourceTestDataLib)
+    endif()
     target_link_libraries(UtilityGlobalStateAcrossLibrariesLibrary PRIVATE CorradeUtility)
 
     corrade_add_test(UtilityGlobalStateAcrossLibrariesTest

--- a/src/Corrade/Utility/Test/ConfigurationTest.cpp
+++ b/src/Corrade/Utility/Test/ConfigurationTest.cpp
@@ -416,7 +416,7 @@ void ConfigurationTest::readonly() {
 
 void ConfigurationTest::readError() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't abuse a directory to simulate a read error.");
     #endif
 

--- a/src/Corrade/Utility/Test/ConfigurationTest.cpp
+++ b/src/Corrade/Utility/Test/ConfigurationTest.cpp
@@ -416,7 +416,7 @@ void ConfigurationTest::readonly() {
 
 void ConfigurationTest::readError() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't abuse a directory to simulate a read error.");
     #endif
 

--- a/src/Corrade/Utility/Test/DirectoryTest.cpp
+++ b/src/Corrade/Utility/Test/DirectoryTest.cpp
@@ -378,7 +378,7 @@ DirectoryTest::DirectoryTest() {
     if(System::isSandboxed()
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
         /** @todo Fix this once I persuade CMake to run XCTest tests properly */
-        && std::getenv("SIMULATOR_MAINSCREEN_SCALE")
+        && !std::getenv("SIMULATOR_MAINSCREEN_SCALE")
         #endif
     ) {
         _testDir = Directory::join(Directory::path(Directory::executableLocation()), "PathTestFiles");
@@ -575,7 +575,7 @@ void DirectoryTest::existsUtf8() {
 void DirectoryTest::isDirectory() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) thinks all paths are files.");
         #endif
         CORRADE_VERIFY(Directory::isDirectory(Directory::join(_testDir, "dir")));
@@ -599,7 +599,7 @@ void DirectoryTest::isDirectorySymlink() {
         CORRADE_EXPECT_FAIL("Symlink support is implemented on Unix systems and Emscripten only.");
         #endif
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) thinks all paths are files.");
         #endif
         CORRADE_VERIFY(Directory::isDirectory(Directory::join(_testDirSymlink, "dir-symlink")));
@@ -646,7 +646,7 @@ void DirectoryTest::isDirectoryNoPermission() {
 void DirectoryTest::isDirectoryUtf8() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) thinks all paths are files.");
         #endif
         CORRADE_VERIFY(Directory::isDirectory(Directory::join(_testDirUtf8, "šňůra")));
@@ -1144,7 +1144,7 @@ void DirectoryTest::executableLocation() {
     #ifdef CORRADE_TARGET_APPLE
     if(System::isSandboxed()) {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
 
@@ -1314,7 +1314,7 @@ void DirectoryTest::tmp() {
     #if defined(CORRADE_TARGET_UNIX) || defined(CORRADE_TARGET_EMSCRIPTEN)
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_VERIFY(Directory::exists(dir));
@@ -1350,7 +1350,7 @@ void DirectoryTest::tmp() {
     /* Verify that it's possible to write stuff there */
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         /* PathTest writes a file named 'a', and often these two tests get run
@@ -1371,7 +1371,7 @@ void DirectoryTest::tmpUtf8() {
 
 void DirectoryTest::list() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1382,7 +1382,7 @@ void DirectoryTest::list() {
 
 void DirectoryTest::listSkipDirectories() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1393,7 +1393,7 @@ void DirectoryTest::listSkipDirectories() {
 
 void DirectoryTest::listSkipDirectoriesSymlinks() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1409,7 +1409,7 @@ void DirectoryTest::listSkipDirectoriesSymlinks() {
 
 void DirectoryTest::listSkipFiles() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1420,7 +1420,7 @@ void DirectoryTest::listSkipFiles() {
 
 void DirectoryTest::listSkipFilesSymlinks() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1436,7 +1436,7 @@ void DirectoryTest::listSkipFilesSymlinks() {
 
 void DirectoryTest::listSkipSpecial() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1447,7 +1447,7 @@ void DirectoryTest::listSkipSpecial() {
 
 void DirectoryTest::listSkipSpecialSymlink() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1459,7 +1459,7 @@ void DirectoryTest::listSkipSpecialSymlink() {
 
 void DirectoryTest::listSkipDotAndDotDot() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1470,7 +1470,7 @@ void DirectoryTest::listSkipDotAndDotDot() {
 
 void DirectoryTest::listSort() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1523,7 +1523,7 @@ void DirectoryTest::listUtf8() {
 
     #ifdef CORRADE_TARGET_APPLE
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1588,7 +1588,7 @@ void DirectoryTest::fileSizeEarlyEof() {
 
 void DirectoryTest::fileSizeDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't test.");
     #endif
 
@@ -1674,7 +1674,7 @@ void DirectoryTest::readEarlyEof() {
 
 void DirectoryTest::readDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't test.");
     #endif
 
@@ -1945,7 +1945,7 @@ void DirectoryTest::copyEmpty() {
 
 void DirectoryTest::copyDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't test.");
     #endif
 
@@ -2230,7 +2230,7 @@ void DirectoryTest::mapReadEmpty() {
 
 void DirectoryTest::mapReadDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't test.");
     #endif
 

--- a/src/Corrade/Utility/Test/DirectoryTest.cpp
+++ b/src/Corrade/Utility/Test/DirectoryTest.cpp
@@ -378,7 +378,7 @@ DirectoryTest::DirectoryTest() {
     if(System::isSandboxed()
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
         /** @todo Fix this once I persuade CMake to run XCTest tests properly */
-        && std::getenv("SIMULATOR_UDID")
+        && std::getenv("SIMULATOR_MAINSCREEN_SCALE")
         #endif
     ) {
         _testDir = Directory::join(Directory::path(Directory::executableLocation()), "PathTestFiles");
@@ -575,7 +575,7 @@ void DirectoryTest::existsUtf8() {
 void DirectoryTest::isDirectory() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) thinks all paths are files.");
         #endif
         CORRADE_VERIFY(Directory::isDirectory(Directory::join(_testDir, "dir")));
@@ -599,7 +599,7 @@ void DirectoryTest::isDirectorySymlink() {
         CORRADE_EXPECT_FAIL("Symlink support is implemented on Unix systems and Emscripten only.");
         #endif
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) thinks all paths are files.");
         #endif
         CORRADE_VERIFY(Directory::isDirectory(Directory::join(_testDirSymlink, "dir-symlink")));
@@ -646,7 +646,7 @@ void DirectoryTest::isDirectoryNoPermission() {
 void DirectoryTest::isDirectoryUtf8() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) thinks all paths are files.");
         #endif
         CORRADE_VERIFY(Directory::isDirectory(Directory::join(_testDirUtf8, "šňůra")));
@@ -1144,7 +1144,7 @@ void DirectoryTest::executableLocation() {
     #ifdef CORRADE_TARGET_APPLE
     if(System::isSandboxed()) {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
 
@@ -1314,7 +1314,7 @@ void DirectoryTest::tmp() {
     #if defined(CORRADE_TARGET_UNIX) || defined(CORRADE_TARGET_EMSCRIPTEN)
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_VERIFY(Directory::exists(dir));
@@ -1350,7 +1350,7 @@ void DirectoryTest::tmp() {
     /* Verify that it's possible to write stuff there */
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         /* PathTest writes a file named 'a', and often these two tests get run
@@ -1371,7 +1371,7 @@ void DirectoryTest::tmpUtf8() {
 
 void DirectoryTest::list() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1382,7 +1382,7 @@ void DirectoryTest::list() {
 
 void DirectoryTest::listSkipDirectories() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1393,7 +1393,7 @@ void DirectoryTest::listSkipDirectories() {
 
 void DirectoryTest::listSkipDirectoriesSymlinks() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1409,7 +1409,7 @@ void DirectoryTest::listSkipDirectoriesSymlinks() {
 
 void DirectoryTest::listSkipFiles() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1420,7 +1420,7 @@ void DirectoryTest::listSkipFiles() {
 
 void DirectoryTest::listSkipFilesSymlinks() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1436,7 +1436,7 @@ void DirectoryTest::listSkipFilesSymlinks() {
 
 void DirectoryTest::listSkipSpecial() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1447,7 +1447,7 @@ void DirectoryTest::listSkipSpecial() {
 
 void DirectoryTest::listSkipSpecialSymlink() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1459,7 +1459,7 @@ void DirectoryTest::listSkipSpecialSymlink() {
 
 void DirectoryTest::listSkipDotAndDotDot() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1470,7 +1470,7 @@ void DirectoryTest::listSkipDotAndDotDot() {
 
 void DirectoryTest::listSort() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1523,7 +1523,7 @@ void DirectoryTest::listUtf8() {
 
     #ifdef CORRADE_TARGET_APPLE
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -1588,7 +1588,7 @@ void DirectoryTest::fileSizeEarlyEof() {
 
 void DirectoryTest::fileSizeDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't test.");
     #endif
 
@@ -1674,7 +1674,7 @@ void DirectoryTest::readEarlyEof() {
 
 void DirectoryTest::readDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't test.");
     #endif
 
@@ -1945,7 +1945,7 @@ void DirectoryTest::copyEmpty() {
 
 void DirectoryTest::copyDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't test.");
     #endif
 
@@ -2230,7 +2230,7 @@ void DirectoryTest::mapReadEmpty() {
 
 void DirectoryTest::mapReadDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) thinks all paths are files, can't test.");
     #endif
 

--- a/src/Corrade/Utility/Test/PathTest.cpp
+++ b/src/Corrade/Utility/Test/PathTest.cpp
@@ -455,7 +455,7 @@ PathTest::PathTest() {
     if(System::isSandboxed()
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
         /** @todo Fix this once I persuade CMake to run XCTest tests properly */
-        && std::getenv("SIMULATOR_UDID")
+        && std::getenv("SIMULATOR_MAINSCREEN_SCALE")
         #endif
     ) {
         _testDir = Path::join(Path::split(*Path::executableLocation()).first(), "PathTestFiles");
@@ -800,7 +800,7 @@ void PathTest::existsUtf8() {
 void PathTest::isDirectory() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) has no idea about file types.");
         #endif
         CORRADE_VERIFY(Path::isDirectory(Path::join(_testDir, "dir")));
@@ -824,7 +824,7 @@ void PathTest::isDirectorySymlink() {
         CORRADE_EXPECT_FAIL("Symlink support is implemented on Unix systems and Emscripten only.");
         #endif
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) has no idea about file types.");
         #endif
         CORRADE_VERIFY(Path::isDirectory(Path::join(_testDirSymlink, "dir-symlink")));
@@ -871,7 +871,7 @@ void PathTest::isDirectoryNoPermission() {
 void PathTest::isDirectoryNonNullTerminated() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) has no idea about file types.");
         #endif
         CORRADE_VERIFY(Path::isDirectory(Path::join(_testDir, "dirX").exceptSuffix(1)));
@@ -882,7 +882,7 @@ void PathTest::isDirectoryNonNullTerminated() {
 void PathTest::isDirectoryUtf8() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) has no idea about file types.");
         #endif
         CORRADE_VERIFY(Path::isDirectory(Path::join(_testDirUtf8, "šňůra")));
@@ -1451,7 +1451,7 @@ void PathTest::executableLocation() {
     #ifdef CORRADE_TARGET_APPLE
     if(System::isSandboxed()) {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
 
@@ -1636,7 +1636,7 @@ void PathTest::temporaryDirectory() {
     #if defined(CORRADE_TARGET_UNIX) || defined(CORRADE_TARGET_EMSCRIPTEN)
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_VERIFY(Path::exists(*temporaryDirectory));
@@ -1684,7 +1684,7 @@ void PathTest::temporaryDirectory() {
     /* Verify that it's possible to write stuff there */
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_VERIFY(Path::write(Path::join(*temporaryDirectory, "a"), "hello"_s));
@@ -1706,7 +1706,7 @@ void PathTest::list() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1733,7 +1733,7 @@ void PathTest::listIterateRangeFor() {
         arrayAppend(out, a);
 
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
     CORRADE_COMPARE_AS(out, Containers::array<Containers::String>({
@@ -1754,7 +1754,7 @@ void PathTest::listEmptyDirectory() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1769,7 +1769,7 @@ void PathTest::listSkipDirectories() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1784,7 +1784,7 @@ void PathTest::listSkipDirectoriesSymlinks() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         #if !defined(CORRADE_TARGET_UNIX) && !defined(CORRADE_TARGET_EMSCRIPTEN)
@@ -1804,7 +1804,7 @@ void PathTest::listSkipFiles() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1819,7 +1819,7 @@ void PathTest::listSkipFilesSymlinks() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         #if !defined(CORRADE_TARGET_UNIX) && !defined(CORRADE_TARGET_EMSCRIPTEN)
@@ -1839,7 +1839,7 @@ void PathTest::listSkipSpecial() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1856,7 +1856,7 @@ void PathTest::listSkipSpecialSymlink() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1871,7 +1871,7 @@ void PathTest::listSkipDotAndDotDot() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1886,7 +1886,7 @@ void PathTest::listSkipEverything() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1900,7 +1900,7 @@ void PathTest::listSort() {
         CORRADE_VERIFY(list);
 
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1911,7 +1911,7 @@ void PathTest::listSort() {
         CORRADE_VERIFY(list);
 
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1923,7 +1923,7 @@ void PathTest::listSort() {
         CORRADE_VERIFY(list);
 
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1959,7 +1959,7 @@ void PathTest::listNonNullTerminated() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1975,7 +1975,7 @@ void PathTest::listTrailingSlash() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -2002,7 +2002,7 @@ void PathTest::listUtf8Result() {
 
     #ifdef CORRADE_TARGET_APPLE
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -2028,7 +2028,7 @@ void PathTest::listUtf8Path() {
     CORRADE_VERIFY(actual);
 
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_UDID"),
+    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
     CORRADE_COMPARE_AS(*actual,
@@ -2086,7 +2086,7 @@ void PathTest::sizeEarlyEof() {
 
 void PathTest::sizeDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) has no idea about file types, can't test.");
     #endif
 
@@ -2255,7 +2255,7 @@ void PathTest::readEarlyEofString() {
 
 void PathTest::readDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) has no idea about file types, can't test.");
     #endif
 
@@ -2635,7 +2635,7 @@ void PathTest::copyEmpty() {
 
 void PathTest::copyDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) has no idea about file types, can't test.");
     #endif
 
@@ -2974,7 +2974,7 @@ void PathTest::mapReadEmpty() {
 
 void PathTest::mapReadDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_UDID"))
+    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) has no idea about file types, can't test.");
     #endif
 

--- a/src/Corrade/Utility/Test/PathTest.cpp
+++ b/src/Corrade/Utility/Test/PathTest.cpp
@@ -455,7 +455,7 @@ PathTest::PathTest() {
     if(System::isSandboxed()
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
         /** @todo Fix this once I persuade CMake to run XCTest tests properly */
-        && std::getenv("SIMULATOR_MAINSCREEN_SCALE")
+        && !std::getenv("SIMULATOR_MAINSCREEN_SCALE")
         #endif
     ) {
         _testDir = Path::join(Path::split(*Path::executableLocation()).first(), "PathTestFiles");
@@ -800,7 +800,7 @@ void PathTest::existsUtf8() {
 void PathTest::isDirectory() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) has no idea about file types.");
         #endif
         CORRADE_VERIFY(Path::isDirectory(Path::join(_testDir, "dir")));
@@ -824,7 +824,7 @@ void PathTest::isDirectorySymlink() {
         CORRADE_EXPECT_FAIL("Symlink support is implemented on Unix systems and Emscripten only.");
         #endif
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) has no idea about file types.");
         #endif
         CORRADE_VERIFY(Path::isDirectory(Path::join(_testDirSymlink, "dir-symlink")));
@@ -871,7 +871,7 @@ void PathTest::isDirectoryNoPermission() {
 void PathTest::isDirectoryNonNullTerminated() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) has no idea about file types.");
         #endif
         CORRADE_VERIFY(Path::isDirectory(Path::join(_testDir, "dirX").exceptSuffix(1)));
@@ -882,7 +882,7 @@ void PathTest::isDirectoryNonNullTerminated() {
 void PathTest::isDirectoryUtf8() {
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "iOS (in a simulator) has no idea about file types.");
         #endif
         CORRADE_VERIFY(Path::isDirectory(Path::join(_testDirUtf8, "šňůra")));
@@ -1451,7 +1451,7 @@ void PathTest::executableLocation() {
     #ifdef CORRADE_TARGET_APPLE
     if(System::isSandboxed()) {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
 
@@ -1636,7 +1636,7 @@ void PathTest::temporaryDirectory() {
     #if defined(CORRADE_TARGET_UNIX) || defined(CORRADE_TARGET_EMSCRIPTEN)
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_VERIFY(Path::exists(*temporaryDirectory));
@@ -1684,7 +1684,7 @@ void PathTest::temporaryDirectory() {
     /* Verify that it's possible to write stuff there */
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_VERIFY(Path::write(Path::join(*temporaryDirectory, "a"), "hello"_s));
@@ -1706,7 +1706,7 @@ void PathTest::list() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1733,7 +1733,7 @@ void PathTest::listIterateRangeFor() {
         arrayAppend(out, a);
 
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
     CORRADE_COMPARE_AS(out, Containers::array<Containers::String>({
@@ -1754,7 +1754,7 @@ void PathTest::listEmptyDirectory() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1769,7 +1769,7 @@ void PathTest::listSkipDirectories() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1784,7 +1784,7 @@ void PathTest::listSkipDirectoriesSymlinks() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         #if !defined(CORRADE_TARGET_UNIX) && !defined(CORRADE_TARGET_EMSCRIPTEN)
@@ -1804,7 +1804,7 @@ void PathTest::listSkipFiles() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1819,7 +1819,7 @@ void PathTest::listSkipFilesSymlinks() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         #if !defined(CORRADE_TARGET_UNIX) && !defined(CORRADE_TARGET_EMSCRIPTEN)
@@ -1839,7 +1839,7 @@ void PathTest::listSkipSpecial() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1856,7 +1856,7 @@ void PathTest::listSkipSpecialSymlink() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1871,7 +1871,7 @@ void PathTest::listSkipDotAndDotDot() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1886,7 +1886,7 @@ void PathTest::listSkipEverything() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1900,7 +1900,7 @@ void PathTest::listSort() {
         CORRADE_VERIFY(list);
 
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1911,7 +1911,7 @@ void PathTest::listSort() {
         CORRADE_VERIFY(list);
 
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1923,7 +1923,7 @@ void PathTest::listSort() {
         CORRADE_VERIFY(list);
 
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1959,7 +1959,7 @@ void PathTest::listNonNullTerminated() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -1975,7 +1975,7 @@ void PathTest::listTrailingSlash() {
 
     {
         #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-        CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+        CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
             "CTest is not able to run XCTest executables properly in the simulator.");
         #endif
         CORRADE_COMPARE_AS(*list, Containers::array<Containers::String>({
@@ -2002,7 +2002,7 @@ void PathTest::listUtf8Result() {
 
     #ifdef CORRADE_TARGET_APPLE
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
 
@@ -2028,7 +2028,7 @@ void PathTest::listUtf8Path() {
     CORRADE_VERIFY(actual);
 
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    CORRADE_EXPECT_FAIL_IF(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
+    CORRADE_EXPECT_FAIL_IF(std::getenv("SIMULATOR_MAINSCREEN_SCALE"),
         "CTest is not able to run XCTest executables properly in the simulator.");
     #endif
     CORRADE_COMPARE_AS(*actual,
@@ -2086,7 +2086,7 @@ void PathTest::sizeEarlyEof() {
 
 void PathTest::sizeDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) has no idea about file types, can't test.");
     #endif
 
@@ -2255,7 +2255,7 @@ void PathTest::readEarlyEofString() {
 
 void PathTest::readDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) has no idea about file types, can't test.");
     #endif
 
@@ -2635,7 +2635,7 @@ void PathTest::copyEmpty() {
 
 void PathTest::copyDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) has no idea about file types, can't test.");
     #endif
 
@@ -2974,7 +2974,7 @@ void PathTest::mapReadEmpty() {
 
 void PathTest::mapReadDirectory() {
     #if defined(CORRADE_TARGET_IOS) && defined(CORRADE_TESTSUITE_TARGET_XCTEST)
-    if(!std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
+    if(std::getenv("SIMULATOR_MAINSCREEN_SCALE"))
         CORRADE_SKIP("iOS (in a simulator) has no idea about file types, can't test.");
     #endif
 


### PR DESCRIPTION
This does a bunch of things:

- with CMake 3.14+ it's no longer needed to use a custom toolchain file, simply setting `CMAKE_SYSTEM_NAME` to iOS does most of the work
- for XCTest however, `CMAKE_OSX_SYSROOT` needs to be set to `iphonesimulator` (doesn't need to be a path, apparently) to make the right libraries found
- then, since XCode 12 however, the `xctest` executable that's found by `FindXCTest` is working only for native macOS executables, which makes all tests break

Attempted solutions:

- using `xcodebuild test`, and the futile attempts to speed that damn thing up, like `test-without-building` instead of `test` and using `-only-test:`, but even then each test run takes 30+ seconds
- starting the simulator explicitly before running tests, which means probably that xcodebuild no longer starts it up and shuts it down for every test case, but still each test run takes 10+ seconds
- there's actually a different `xctest` executable, `/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/xctest`, unfortunately it doesn't work out-of-the box either and relies on a ton of undocumented env vars set "just right"

All env vars supplied to it from `xcodebuild` are the following, as can be seen in `ArgumentsTest` in the CI output, and if all are set it works:

```sh
export IOS_SIMULATOR_SYSLOG_SOCKET=/tmp/com.apple.CoreSimulator.SimDevice.A8176C67-F1D0-4517-A6B5-A3495829BB1D/syslogsock
export SIMULATOR_SHARED_RESOURCES_DIRECTORY=/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data
export XPC_SIMULATOR_LAUNCHD_NAME=com.apple.CoreSimulator.SimDevice.A8176C67-F1D0-4517-A6B5-A3495829BB1D
export DYLD_SHARED_CACHE_DIR=/Users/distiller/Library/Developer/CoreSimulator/Caches/dyld/20F71/com.apple.CoreSimulator.SimRuntime.iOS-14-5.18E182
export IPHONE_SIMULATOR_ROOT=/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
export LS_ENABLE_BUNDLE_LOCALIZATION_CACHING=1
export SIMULATOR_HID_SYSTEM_MANAGER=/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Resources/Platforms/iphoneos/Library/Frameworks/SimulatorHID.framework
export SIMULATOR_MAINSCREEN_HEIGHT=2532
export SIMULATOR_MEMORY_WARNINGS=/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data/var/run/memory_warning_simulation
export SIMULATOR_AUDIO_DEVICES_PLIST_PATH=/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data/var/run/com.apple.coresimulator.audio.plist
export SIMULATOR_LOG_ROOT=/Users/distiller/Library/Logs/CoreSimulator/A8176C67-F1D0-4517-A6B5-A3495829BB1D
export SIMULATOR_RUNTIME_BUILD_VERSION=18E182
export DYLD_ROOT_PATH=/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
export PATH=/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/bin:/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/bin:/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/sbin:/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/sbin:/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/local/bin
export SIMULATOR_HOST_HOME=/Users/distiller
export SIMULATOR_ROOT=/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
export IPHONE_SHARED_RESOURCES_DIRECTORY=/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data
export IPHONE_TVOUT_EXTENDED_PROPERTIES="/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data/Library/Application Support/Simulator/extended_display.plist"
export SIMULATOR_BOOT_TIME=1692094651
export SIMULATOR_CAPABILITIES="/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 12.simdevicetype/Contents/Resources/capabilities.plist"
export SIMULATOR_FRAMEBUFFER_FRAMEWORK=/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Resources/Platforms/iphoneos/Library/PrivateFrameworks/SimFramebuffer.framework/SimFramebuffer
export SIMULATOR_LEGACY_ASSET_SUFFIX=iphone
export SIMULATOR_MAINSCREEN_PITCH=460.000000
export SIMULATOR_MAINSCREEN_WIDTH=1170
export SIMULATOR_MODEL_IDENTIFIER=iPhone13,2
export SIMULATOR_PRODUCT_CLASS=D53g
export SIMULATOR_RUNTIME_VERSION=14.5
export SIMULATOR_ARCHS=x86_64
export SIMULATOR_AUDIO_SETTINGS_PATH=/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data/var/run/simulatoraudio/audiosettings.plist
export SIMULATOR_DEVICE_NAME="iPhone 12"
export SIMULATOR_EXTENDED_DISPLAY_PROPERTIES="/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data/Library/Application Support/Simulator/extended_display.plist"
export SIMULATOR_MAINSCREEN_SCALE=3.000000
export SIMULATOR_UDID=A8176C67-F1D0-4517-A6B5-A3495829BB1D
export SIMULATOR_VERSION_INFO="CoreSimulator 757.5 - Device: iPhone 12 (A8176C67-F1D0-4517-A6B5-A3495829BB1D) - Runtime: iOS 14.5 (18E182) - DeviceType: iPhone 12"
export RUN_DESTINATION_DEVICE_NAME="iPhone 12"
export CA_ASSERT_MAIN_THREAD_TRANSACTIONS=0
export DYLD_LIBRARY_PATH=/Users/distiller/project/build-ios/Release/lib
export XCTestBundlePath=/Users/distiller/project/build-ios/Release/lib/UtilityArgumentsTestRunner.xctest
export RUN_DESTINATION_DEVICE_PLATFORM_IDENTIFIER=com.apple.platform.iphonesimulator
export MTC_CRASH_ON_REPORT=1
export RUN_DESTINATION_DEVICE_UDID=A8176C67-F1D0-4517-A6B5-A3495829BB1D
export __XCODE_BUILT_PRODUCTS_DIR_PATHS=/Users/distiller/project/build-ios/Release/lib
export __XPC_DYLD_LIBRARY_PATH=/Users/distiller/project/build-ios/Release/lib
export NSUnbufferedIO=YES
export XCTestSessionIdentifier=1318C309-2A13-40B3-B47B-B99C87CD0BCE
export XCTestConfigurationFilePath=
export OS_ACTIVITY_DT_MODE=YES
export __XPC_DYLD_FRAMEWORK_PATH=/Users/distiller/project/build-ios/Release/lib
export SQLITE_ENABLE_THREAD_ASSERTIONS=1
export CA_DEBUG_TRANSACTIONS=0
export DYLD_FRAMEWORK_PATH=/Users/distiller/project/build-ios/Release/lib
export XPC_SERVICE_NAME=com.apple.xpc.launchd.oneshot.0x10000000.xctest
export TESTMANAGERD_REMOTE_AUTOMATION_SIM_SOCK=/private/tmp/com.apple.launchd.5rU88t2Ehi/com.apple.testmanagerd.remote-automation.unix-domain.socket
export TESTMANAGERD_SIM_SOCK=/private/tmp/com.apple.launchd.pMD5m4njkX/com.apple.testmanagerd.unix-domain.socket
export CUPS_SERVER=/private/tmp/com.apple.launchd.dyYDCHY7Sl/Listeners
export RWI_LISTEN_SOCKET=/private/tmp/com.apple.launchd.l23jlUNq0c/com.apple.webinspectord_sim.socket
export DYLD_FALLBACK_FRAMEWORK_PATH=/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks
export CFFIXED_USER_HOME=/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data
export DYLD_FALLBACK_LIBRARY_PATH=/Applications/Xcode-12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib
export HOME=/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data
export TMPDIR=/Users/distiller/Library/Developer/CoreSimulator/Devices/A8176C67-F1D0-4517-A6B5-A3495829BB1D/data/tmp/
export XPC_FLAGS=0x0
```

Things to do:

- [ ] Override the `xctest` executable to be taken for the simulator
  - [ ] Upstream that to CMake?
- [ ] Figure out a reasonable subset of the above and supply those in `UseCorrade`
- [ ] In both cases, whether with `xcodebuild test` or with `xctest`, the user still needs to supply an iPhone version, and whether it's a device or simulator. That's done with `CORRADE_TESTSUITE_XCTEST_DESTINATION` now.
  - [ ] Document this
  - [ ] Have some reasonable autodetected default? "latest iPhone simulator available"?
- [ ] Deprecate `CORRADE_TARGET_IOS_SIMULATOR` CMake var as it's impossible to detect in CMake
  - [ ] Deprecate the preprocessor var as well, unless it's detectable some other way
- [ ] Clean up the XFAILs in the test (a check for `SIMULATOR_UDID` *not* existing was for the original hacky `xctest` run, the change to `SIMULATOR_MAINSCREEN_SCALE` is totally random and it now XPASSes certain tests)