### PR TITLE
Fix ambiguous use of format with new Apple Clang and C++20

### DIFF
--- a/src/Corrade/Utility/Implementation/ResourceCompile.h
+++ b/src/Corrade/Utility/Implementation/ResourceCompile.h
@@ -115,7 +115,7 @@ Containers::String resourceCompile(const Containers::StringView name, const Cont
 
     /* Special case for empty file list */
     if(files.isEmpty()) {
-        return format(R"(/* Compiled resource file. DO NOT EDIT! */
+        return Utility::format(R"(/* Compiled resource file. DO NOT EDIT! */
 
 #include "Corrade/Corrade.h"
 #include "Corrade/Utility/Macros.h"
@@ -214,7 +214,7 @@ int resourceFinalizer_{0}() {{
        about functions which don't have corresponding declarations (enabled by
        -Wmissing-declarations in GCC). If we don't have any data, we don't
        create the resourceData array, as zero-length arrays are not allowed. */
-    return format(R"(/* Compiled resource file. DO NOT EDIT! */
+    return Utility::format(R"(/* Compiled resource file. DO NOT EDIT! */
 
 #include "Corrade/Corrade.h"
 #include "Corrade/Utility/Macros.h"
@@ -361,7 +361,7 @@ Containers::String resourceCompileSingle(const Containers::StringView name, cons
         dataHexcode.resize(dataHexcode.size() - 2);
     }
 
-    return format(R"(/* Compiled resource file. DO NOT EDIT! */
+    return Utility::format(R"(/* Compiled resource file. DO NOT EDIT! */
 
 extern const unsigned int resourceSize_{0} = {1};
 extern const unsigned char resourceData_{0}[] = {{


### PR DESCRIPTION
I just updated XCode which updated to `AppleClang 16.0.0.16000026` and the found the unqualified uses of `format` here now produce a compile error about the call to `format` being ambiguous. This PR fixes the compile issue by qualifying the use with the `Utility` namespace. The ambiguous use occurs when targetting C++20, as I didn't repro it when just building corrade on its own, but in a project that enables C++20 I do see the ambiguous use error. If I target C++20 when building corrade, I can repro the compile issue:

```
In file included from /Users/will/repos/corrade/src/Corrade/Utility/rc.cpp:30:
/Users/will/repos/corrade/src/Corrade/Utility/Implementation/ResourceCompile.h:217:12: error: call to 'format' is ambiguous
  217 |     return format(R"(/* Compiled resource file. DO NOT EDIT! */
      |            ^~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/usr/include/c++/v1/__format/format_functions.h:476:1: note: candidate function [with _Args = <std::string &, std::string &, Corrade::Containers::BasicStringView<const char>, Corrade::Containers::String, std::string &, const Corrade::Containers::BasicStringView<const char> &, const Corrade::Containers::BasicStringView<const char> &, unsigned long, const char *>]
  476 | format(format_string<_Args...> __fmt, _Args&&... __args) {
      | ^
/Users/will/repos/corrade/src/Corrade/Utility/Format.h:349:71: note: candidate function [with Args = <std::string, std::string, Corrade::Containers::BasicStringView<const char>, Corrade::Containers::String, std::string, Corrade::Containers::BasicStringView<const char>, Corrade::Containers::BasicStringView<const char>, unsigned long, const char *>, String = Corrade::Containers::String, MutableStringView = Corrade::Containers::BasicStringView<char>]
  349 | template<class ...Args, class String, class MutableStringView> String format(const char* format, const Args&... args) {
      |                                                                       ^
```