### PR TITLE
Attempt to circumvent ASLR issues with ThreadSanitizer

### DIFF
--- a/doc/corrade-changelog.dox
+++ b/doc/corrade-changelog.dox
@@ -601,6 +601,8 @@ namespace Corrade {
 -   The @ref corrade-rc "corrade-rc" utility now embeds a version identifier in
     generated output to prevent use of a stale binary in case it's for example
     bundled for cross-compiling (see [mosra/magnum#656](https://github.com/mosra/magnum/issues/656))
+-   The Linux ThreadSanitizer CI build was updated to work with ASLR again
+    (see [mosra/corrade#191](https://github.com/mosra/corrade/pull/191))
 
 @subsection corrade-changelog-latest-bugfixes Bug fixes
 

--- a/package/ci/circleci.yml
+++ b/package/ci/circleci.yml
@@ -74,30 +74,18 @@ commands:
       extra:
         type: string
         default: ""
+      sudo:
+        type: string
+        default: ""
     steps:
     - run:
         # TODO when switching to the new codecov uploader, gpg and git needs to
         #   be installed as well
         name: Update apt and install base packages
         command: |
-          apt update
+          << parameters.sudo >> apt update
           if [[ "$CMAKE_CXX_FLAGS" == *"--coverage"* ]]; then export LCOV_PACKAGES="lcov curl"; fi
-          # libidn11 needed by CMake
-          apt install -y ninja-build libidn11 $LCOV_PACKAGES << parameters.extra >>
-
-  install-base-linux-arm64:
-    parameters:
-      extra:
-        type: string
-        default: ""
-    steps:
-    - run:
-        name: Update apt and install base packages
-        # Compared to Docker images this needs sudo
-        command: |
-          sudo apt update
-          if [[ "$CMAKE_CXX_FLAGS" == *"--coverage"* ]]; then export LCOV_PACKAGES="lcov curl"; fi
-          sudo apt install -y ninja-build gcc cmake $LCOV_PACKAGES << parameters.extra >>
+          << parameters.sudo >> apt install -y ninja-build $LCOV_PACKAGES << parameters.extra >>
 
   # TODO this might get resolved with 1.11.1:
   #   https://github.com/ninja-build/ninja/pull/1827
@@ -310,9 +298,10 @@ jobs:
       LCOV_EXTRA_OPTS: --gcov-tool /usr/bin/gcov-4.8
       CONFIGURATION: Debug
     steps:
-    # Install also Git so we verify that Git version embedding works
+    # libidn11 needed by CMake. Install also Git so we verify that Git version
+    # embedding works
     - install-base-linux:
-        extra: git
+        extra: libidn11 git
     # OOMs during compilation of Strided[Bit]ArrayViewTest
     # TODO revisit once deprecated includes are dropped (non-deprecated build
     # doesn't fail), https://github.com/mosra/corrade/pull/140 may also help?
@@ -332,8 +321,10 @@ jobs:
       CONFIGURATION: Debug
     steps:
     # Not installing the old GCC 4.8 and CMake 3.5 to speed up. These are
-    # tested more than enough on other jobs.
-    - install-base-linux-arm64
+    # tested more than enough on other jobs. Machine executors need sudo.
+    - install-base-linux:
+        extra: gcc cmake
+        sudo: sudo
     - make-expected-linux-dirs
     - build:
         script: unix-desktop.sh
@@ -349,7 +340,9 @@ jobs:
       LCOV_EXTRA_OPTS: --gcov-tool /usr/bin/gcov-4.8
       CONFIGURATION: Debug
     steps:
-    - install-base-linux
+    # libidn11 needed by CMake
+    - install-base-linux:
+        extra: libidn11
     # OOMs during compilation of Strided[Bit]ArrayViewTest
     # TODO revisit once deprecated includes are dropped (non-deprecated build
     # doesn't fail), https://github.com/mosra/corrade/pull/140 may also help?
@@ -370,7 +363,9 @@ jobs:
       CMAKE_CXX_FLAGS: -DCORRADE_NO_ASSERT
       CONFIGURATION: Release
     steps:
-    - install-base-linux
+    # libidn11 needed by CMake
+    - install-base-linux:
+        extra: libidn11
     - cap-ninja-jobs
     - install-gcc-4_8
     - install-cmake:
@@ -385,7 +380,9 @@ jobs:
       CMAKE_CXX_FLAGS: -fsanitize=address
       CONFIGURATION: Debug
     steps:
-    - install-base-linux
+    # libidn11 needed by CMake
+    - install-base-linux:
+        extra: libidn11
     - install-clang
     - install-cmake:
         version: "3.5.2"

--- a/package/ci/circleci.yml
+++ b/package/ci/circleci.yml
@@ -15,6 +15,11 @@ executors:
   ubuntu-18_04:
     docker:
     - image: ubuntu:bionic-20220427
+  # Used by the ThreadSanitizer build. Cannot be a Docker because we need to
+  # disable ASLR which can only be done with a real VM.
+  ubuntu-20_04:
+    machine:
+      image: ubuntu-2004:2024.11.1
   # Anything below 13.4.1 (and all x86 variants) are deprecated as of June 28th
   # 2024
   xcode-13_4:
@@ -156,30 +161,41 @@ commands:
   # embedded toolchains still use it, for Clang we just pick the version
   # available in the oldest supported distro.
   install-clang:
+    parameters:
+      sudo:
+        type: string
+        default: ""
+      symbolizer-link:
+        type: boolean
+        default: true
     steps:
     - run:
-        # For some reason, CMake needs a working C compiler, so provice CC as
+        # For some reason, CMake needs a working C compiler, so provide CC as
         # well for the case when default gcc isn't installed.
-        #
-        # The llvm-symbolizer link needs to be set in order to have usable
-        # symbols in the output. This affects suppressions as well, meaning
-        # they won't work if the symbols are not resolvable. It's not enough to
-        # just `export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-6.0`
-        # because it then complains that
-        #
-        #   External symbolizer path is set to '/usr/bin/llvm-symbolizer-6.0'
-        #   which isn't a known symbolizer. Please set the path to the
-        #   llvm-symbolizer binary or other known tool.
-        #
-        # Probably because because it detects tool type based on the filename?
-        # Ugh.
         name: Install Clang
         command: |
-          apt install -y clang
+          << parameters.sudo >> apt install -y clang
           echo 'export CC=clang' >> $BASH_ENV
           echo 'export CXX=clang++' >> $BASH_ENV
-          ls -l /usr/bin/llvm-symbolizer-6.0
-          ln -s /usr/bin/llvm-symbolizer{-6.0,}
+    # With Clang 6 on 18.04, the llvm-symbolizer link needs to be set in order
+    # to have usable symbols in the output. This affects suppressions as well,
+    # meaning they won't work if the symbols are not resolvable. It's not
+    # enough to just `export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-6.0`
+    # because it then complains that
+    #
+    #   External symbolizer path is set to '/usr/bin/llvm-symbolizer-6.0' which
+    #   isn't a known symbolizer. Please set the path to the llvm-symbolizer
+    #   binary or other known tool.
+    #
+    # Probably because because it detects tool type based on the filename? Ugh.
+    - when:
+        condition: << parameters.symbolizer-link >>
+        steps:
+        - run:
+            name: Create /usr/bin/llvm-symbolizer symlink
+            command: |
+              ls -l /usr/bin/llvm-symbolizer-6.0
+              ln -s /usr/bin/llvm-symbolizer{-6.0,}
 
   install-cmake:
     parameters:
@@ -390,17 +406,40 @@ jobs:
     - build:
         script: unix-desktop.sh
 
+  # https://github.com/google/sanitizers/issues/1716 ; started happening on
+  # 2024-11-08 as CircleCI uses a base system with kernel 6.5 instead of 5.15
+  # for Docker images:
+  #   https://discuss.circleci.com/t/docker-executor-infrastructure-upgrade/52282
+  # This manifests when running corrade-rc already:
+  #   ThreadSanitizer: unexpected memory mapping 0x7e2f226ae000-0x7e2f22b00000
+  # Unfortunately, with Docker images, none of the suggested
+  #   sysctl vm.mmap_rnd_bits=28
+  #   echo 0 | tee /proc/sys/kernel/randomize_va_space
+  # works, complaining about read-only filesystem. The only way to set those is
+  # with a real VM instead of Docker, which is what's done here. It also means
+  # it's not possible to test on 18.04 anymore as those VMs are no longer
+  # provided.
   linux-threadsanitizer:
-    executor: ubuntu-18_04
+    executor: ubuntu-20_04
     environment:
       CMAKE_CXX_FLAGS: -fsanitize=thread
       CONFIGURATION: Debug
     steps:
-    - install-base-linux
-    - install-clang
-    - install-cmake:
-        version: "3.5.2"
+    - install-base-linux:
+        extra: cmake
+        sudo: sudo
+    - install-clang:
+        sudo: sudo
+        symbolizer-link: false
     - make-expected-linux-dirs
+    - run:
+        # Right now (2025-01-17) it's already set to 28 so nothing needs to be
+        # changed. This is for the future when it may break again, and yes,
+        # setting it explicitly to 32 causes the above error again.
+        name: Ensure ASLR is compatible with ThreadSanitizer
+        command: |
+          sudo sysctl vm.mmap_rnd_bits
+          sudo sysctl vm.mmap_rnd_bits=28
     - build:
         script: unix-desktop.sh
 


### PR DESCRIPTION
As of 2024-11-08, CircleCI uses a base system with kernel 6.5 instead of 5.15: https://discuss.circleci.com/t/docker-executor-infrastructure-upgrade/52282 That makes the TSan job to fail because it hits https://github.com/google/sanitizers/issues/1716 . 

- Neither of the suggested solutions (`sysctl vm.mmap_rnd_bits=28`, `echo 0 | tee /proc/sys/kernel/randomize_va_space`) work because the filesystem is readonly on the Docker image. 
- Tried to use Clang 18 instead, however that only makes it fail later down the line, with `ThreadSanitizer: CHECK failed: tsan_platform_linux.cpp:282 "((personality(old_personality | ADDR_NO_RANDOMIZE))) != ((-1))" (0xffffffffffffffff, 0xffffffffffffffff)`. This problem however seems so rare that there's nothing to be found for it, except https://github.com/ClickHouse/ClickHouse/issues/64086 where I have no idea what could I do in order to fix this. There it's related to getauxval, so maybe in my case it's related to CPU dispatch? Ifunc isn't used with sanitizers, tho, and disabling CPU dispatch completely for sanitizer builds will just lead to a xz-level security nightmare.
- The problem _sometimes_ goes away and the TSan build passes, but that's only because a 5.15 runner was randomly chosen instead of 6.5. Such as in https://circleci.com/gh/mosra/corrade/14047.

The only solution is to switch from Docker to a real VM, which is what this PR ultimately does.