### PR TITLE
Fix use of deprecated UDL syntax

### DIFF
--- a/src/Corrade/Containers/StringView.h
+++ b/src/Corrade/Containers/StringView.h
@@ -1496,7 +1496,7 @@ The returned instance has both @ref StringViewFlag::Global and
 @ref Containers-BasicStringView-usage for more information.
 @m_keywords{_s s}
 */
-constexpr StringView operator"" _s(const char* data, std::size_t size) {
+constexpr StringView operator""_s(const char* data, std::size_t size) {
     /* Using plain bit ops instead of EnumSet to speed up debug builds */
     return StringView{data, size, StringViewFlag(std::size_t(StringViewFlag::Global)|std::size_t(StringViewFlag::NullTerminated))};
 }


### PR DESCRIPTION
C++23 has deprecated spaces between quotes and suffix in user-defined string literals. See [C++23 draft N4950 [depr.lit] (Annex D.9)](https://timsong-cpp.github.io/cppwp/n4950/depr.lit).

This addresses the following GCC 15 compiler warnings:
```
warning: space between quotes and suffix is deprecated in C++23 [-Wdeprecated-literal-operator]
```

See also:
- https://github.com/mosra/magnum/pull/674