### PR TITLE
Fix shadow-uncaptured-local warnings in Format.h

### DIFF
--- a/src/Corrade/Utility/Format.h
+++ b/src/Corrade/Utility/Format.h
@@ -315,8 +315,8 @@ struct BufferFormatter {
     /*implicit*/ constexpr BufferFormatter(): _fn{}, _value{} {}
 
     template<class T> explicit BufferFormatter(const T& value): _value{&value} {
-        _fn = [](const Containers::MutableStringView& buffer, const void* value, int precision, FormatType type) {
-            return Formatter<typename std::decay<T>::type>::format(buffer, *static_cast<const T*>(value), precision, type);
+        _fn = [](const Containers::MutableStringView& buffer, const void* val, int precision, FormatType type) {
+            return Formatter<typename std::decay<T>::type>::format(buffer, *static_cast<const T*>(val), precision, type);
         };
     }
 
@@ -337,8 +337,8 @@ struct FileFormatter {
     /*implicit*/ constexpr FileFormatter(): _fn{}, _value{} {}
 
     template<class T> explicit FileFormatter(const T& value): _value{&value} {
-        _fn = [](std::FILE* file, const void* value, int precision, FormatType type) {
-            Formatter<typename std::decay<T>::type>::format(file, *static_cast<const T*>(value), precision, type);
+        _fn = [](std::FILE* file, const void* val, int precision, FormatType type) {
+            Formatter<typename std::decay<T>::type>::format(file, *static_cast<const T*>(val), precision, type);
         };
     }
 


### PR DESCRIPTION
Triggered when using "-Wshadow-uncaptured-local" on Apple clang version 17.0.0 (clang-1700.3.19.1)