### PR TITLE
Utility: (attempt to) use a Clang 14+ pragma for CORRADE_DEPRECATED_MACRO()

### DIFF
--- a/src/Corrade/Utility/DeprecationMacros.h
+++ b/src/Corrade/Utility/DeprecationMacros.h
@@ -240,14 +240,16 @@ On compilers other than GCC, Clang and MSVC the macro does nothing.
     @ref CORRADE_DEPRECATED_FILE()
 */
 #ifndef CORRADE_DEPRECATED_MACRO
-#ifdef CORRADE_TARGET_CLANG
-#define CORRADE_DEPRECATED_MACRO(macro,message) _Pragma(_CORRADE_HELPER_STR(GCC warning ("this macro is deprecated: " message)))
+#if defined(CORRADE_TARGET_CLANG) && __clang_major__ >= 14
+#define CORRADE_DEPRECATED_MACRO(macro, message) _Pragma(_CORRADE_HELPER_STR(clang deprecated(macro, message)))
+#elif defined(CORRADE_TARGET_CLANG)
+#define CORRADE_DEPRECATED_MACRO(macro, message) _Pragma(_CORRADE_HELPER_STR(GCC warning ("this macro is deprecated: " message)))
 #elif defined(CORRADE_TARGET_GCC)
-#define CORRADE_DEPRECATED_MACRO(macro,message) _Pragma(_CORRADE_HELPER_STR(GCC warning message))
+#define CORRADE_DEPRECATED_MACRO(macro, message) _Pragma(_CORRADE_HELPER_STR(GCC warning message))
 #elif defined(CORRADE_TARGET_MSVC)
-#define CORRADE_DEPRECATED_MACRO(macro,_message) __pragma(message (__FILE__ ": warning: " _CORRADE_HELPER_STR(macro) " is deprecated: " _message))
+#define CORRADE_DEPRECATED_MACRO(macro, _message) __pragma(message (__FILE__ ": warning: " _CORRADE_HELPER_STR(macro) " is deprecated: " _message))
 #else
-#define CORRADE_DEPRECATED_MACRO(macro,message)
+#define CORRADE_DEPRECATED_MACRO(macro, message)
 #endif
 #endif
 

--- a/src/Corrade/Utility/Test/DeprecationMacrosTest.cpp
+++ b/src/Corrade/Utility/Test/DeprecationMacrosTest.cpp
@@ -87,7 +87,7 @@ namespace CORRADE_DEPRECATED_NAMESPACE("use Namespace instead") DeprecatedNamesp
 }
 #define MACRO(foo) do {} while(false)
 #define DEPRECATED_MACRO(foo) \
-    CORRADE_DEPRECATED_MACRO(DEPRECATED_MACRO(),"ignore me, I'm just testing the CORRADE_DEPRECATED_MACRO() macro") MACRO(foo)
+    CORRADE_DEPRECATED_MACRO(DEPRECATED_MACRO, "ignore me, I'm just testing the CORRADE_DEPRECATED_MACRO() macro") MACRO(foo)
 
 /* Uncomment to test various subsets of deprecation warnings */
 // #define ENABLE_DEPRECATION_WARNINGS
@@ -174,6 +174,8 @@ void DeprecationMacrosTest::deprecatedMacro() {
     /* Warning on MSVC, GCC, Clang. Can only be disabled with
        CORRADE_IGNORE_DEPRECATED_PUSH on Clang, not on GCC or MSVC. */
     DEPRECATED_MACRO(hello?);
+    // TODO argh the above doesn't warn, only a subsequent use of the same macro, what to do?!
+    DEPRECATED_MACRO(now it does);
 
     CORRADE_VERIFY(true);
 }


### PR DESCRIPTION
Well, except that the way I'm using it doesn't really work, it would need to be a standalone declaration independent from the macro definition itself. Which ... makes it pretty much useless, sigh.

The original proposal at https://reviews.llvm.org/D67935 implemented an approach that's exactly matching my use case, but the final version at https://github.com/llvm/llvm-project/commit/26c695b7893071d5e69afbaa70c4850ab2e468be doesn't seem to support that anymore, and is thus impossible to be wrapped in a compiler-independent macro. Sigh.